### PR TITLE
Custom strings + improvements round

### DIFF
--- a/examples/custom-strings/download
+++ b/examples/custom-strings/download
@@ -17,38 +17,36 @@ version_command() {
 
 # :command.usage
 download_usage() {
-  echo -e "download - Sample minimal application without subcommands"
+  echo -e "download - Sample minimal application with custom strings"
   echo 
-  echo -e "Usage:"
-  echo -e "  download SOURCE [TARGET] [options]"
+  echo -e "== Usage ==
+"
+  echo -e "  download SOURCE [options]"
   echo
 
 
   if [[ -n $long_usage ]]; then
-    echo -e "Options:"
+    echo -e "== Options ==
+"
     # :command.usage_fixed_flags
     echo "  --help, -h"
-    echo -e "    Show this help"
+    echo -e "    Show this helpful help"
     echo
     echo "  --version"
     echo -e "    Show version number"
     echo
     # :command.usage_flags
     # :flag.usage
-    echo "  --force, -f"
-    echo "    Overwrite existing files"
+    echo "  --out, -o DIR (required)"
+    echo "    Target directory"
     echo
     # :command.usage_args
-    echo -e "Arguments:"
+    echo -e "== Arguments ==
+    "
     
     # :argument.usage
     echo "  SOURCE"
     echo "    URL to download from"
-    echo
-    
-    # :argument.usage
-    echo "  TARGET"
-    echo "    Target filename (default: same as source)"
     echo
 
   fi
@@ -86,18 +84,29 @@ parse_args() {
     args[source]=$1
     shift
   else
-    echo -e "missing required argument: SOURCE\nusage: download SOURCE [TARGET] [options]"
+    echo -e "Boom! a required argument is missing: SOURCE\nusage: download SOURCE [options]"
     exit 1
   fi
   # :command.required_flags_filter
+  argstring="$*"
+  if [[ "$argstring" != *--out* && "$argstring" != *-o* ]]; then
+    echo -e "Yo! you forgot a flag: --out, -o DIR"
+    exit 1
+  fi
   # :command.parse_args_while
   while [[ $# -gt 0 ]]; do
     key="$1"
     case "$key" in
     # :flag.case
-    --force | -f )
-      args[--force]=1
-      shift
+    --out | -o )
+      if [[ $2 && $2 != -* ]]; then
+        args[--out]="$2"
+        shift
+        shift
+      else
+        echo -e "Hey! the flag --out requires an argument: --out, -o DIR"
+        exit 1
+      fi
       ;;
   
   
@@ -110,9 +119,6 @@ parse_args() {
       # :command.parse_args_case
       if [[ ! ${args[source]} ]]; then
         args[source]=$1
-        shift
-      elif [[ ! ${args[target]} ]]; then
-        args[target]=$1
         shift
       else
         echo -e "invalid argument: $key"

--- a/examples/custom-strings/src/bashly-strings.yml
+++ b/examples/custom-strings/src/bashly-strings.yml
@@ -1,0 +1,17 @@
+# Usage captions
+usage: "== Usage ==\n"
+options: "== Options ==\n"
+arguments: "== Arguments ==\n"
+commands: "== Commands ==\n"
+
+# Fixed flags help text
+show_this_help: Show this helpful help
+show_version_number: Show version number
+
+# Error messages
+flag_requires_an_argument: "Hey! the flag %{long} requires an argument: %{usage}"
+invalid_argument: "invalid argument: %{arg}"
+invalid_flag: "invalid option: %{flag}"
+missing_required_argument: "Boom! a required argument is missing: %{arg}\\nusage: %{usage}"
+missing_required_flag: "Yo! you forgot a flag: %{usage}"
+

--- a/examples/custom-strings/src/bashly.yml
+++ b/examples/custom-strings/src/bashly.yml
@@ -1,0 +1,16 @@
+name: download
+help: Sample minimal application with custom strings
+version: 0.1.0
+
+args:
+- name: source
+  required: true
+  help: URL to download from
+
+flags:
+- long: --out
+  short: -o
+  arg: dir
+  required: true
+  help: Target directory
+

--- a/examples/custom-strings/src/root_command.sh
+++ b/examples/custom-strings/src/root_command.sh
@@ -1,0 +1,3 @@
+echo "# this file is located in 'src/root_command.sh'"
+echo "# you can edit it freely and regenerate (it will not be overwritten)"
+inspect_args

--- a/examples/custom-strings/test.sh
+++ b/examples/custom-strings/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x
+
+rm -f ./src/*.sh
+
+bashly generate
+
+./download
+./download -h
+./download somesource
+./download somesource -o

--- a/examples/minimal/download
+++ b/examples/minimal/download
@@ -25,7 +25,7 @@ download_usage() {
 
 
   if [[ -n $long_usage ]]; then
-    echo "Options:"
+    echo "Options::"
     # :command.usage_fixed_flags
     echo "  --help, -h"
     echo "    Show this help"
@@ -39,7 +39,7 @@ download_usage() {
     echo "    Overwrite existing files"
     echo
     # :command.usage_args
-    echo "Arguments:"
+    echo "Arguments::"
     
     # :argument.usage
     echo "  SOURCE"
@@ -86,8 +86,7 @@ parse_args() {
     args[source]=$1
     shift
   else
-    echo "missing required argument: SOURCE"
-    echo "Usage: download SOURCE [TARGET] [options]"
+    echo -e "missing required argument: SOURCE\nusage: download SOURCE [TARGET] [options]"
     exit 1
   fi
   # :command.required_flags_filter

--- a/examples/subcommands/cli
+++ b/examples/subcommands/cli
@@ -10,25 +10,25 @@ version_command() {
 
 # :command.usage
 cli_usage() {
-  echo "cli - Sample application"
+  echo -e "cli - Sample application"
   echo 
-  echo "Usage:"
-  echo "  cli [command] [options]"
+  echo -e "Usage:"
+  echo -e "  cli [command] [options]"
   echo
   # :command.usage_commands
-  echo "Commands::"
+  echo -e "Commands:"
   echo "  download   Download a file"
   echo "  upload     Upload a file"
   echo
 
   if [[ -n $long_usage ]]; then
-    echo "Options::"
+    echo -e "Options:"
     # :command.usage_fixed_flags
     echo "  --help, -h"
-    echo "    Show this help"
+    echo -e "    Show this help"
     echo
     echo "  --version"
-    echo "    Show version number"
+    echo -e "    Show version number"
     echo
 
 
@@ -38,21 +38,21 @@ cli_usage() {
 
 # :command.usage
 cli_download_usage() {
-  echo "cli download - Download a file"
+  echo -e "cli download - Download a file"
   echo 
-  echo "Usage:"
-  echo "  cli download SOURCE [TARGET] [options]"
+  echo -e "Usage:"
+  echo -e "  cli download SOURCE [TARGET] [options]"
   echo
 
 
   if [[ -n $long_usage ]]; then
-    echo "Options::"
+    echo -e "Options:"
     # :command.usage_fixed_flags
     echo "  --help, -h"
-    echo "    Show this help"
+    echo -e "    Show this help"
     echo
     echo "  --version"
-    echo "    Show version number"
+    echo -e "    Show version number"
     echo
     # :command.usage_flags
     # :flag.usage
@@ -60,7 +60,7 @@ cli_download_usage() {
     echo "    Overwrite existing files"
     echo
     # :command.usage_args
-    echo "Arguments::"
+    echo -e "Arguments:"
     
     # :argument.usage
     echo "  SOURCE"
@@ -78,21 +78,21 @@ cli_download_usage() {
 
 # :command.usage
 cli_upload_usage() {
-  echo "cli upload - Upload a file"
+  echo -e "cli upload - Upload a file"
   echo 
-  echo "Usage:"
-  echo "  cli upload SOURCE [options]"
+  echo -e "Usage:"
+  echo -e "  cli upload SOURCE [options]"
   echo
 
 
   if [[ -n $long_usage ]]; then
-    echo "Options::"
+    echo -e "Options:"
     # :command.usage_fixed_flags
     echo "  --help, -h"
-    echo "    Show this help"
+    echo -e "    Show this help"
     echo
     echo "  --version"
-    echo "    Show version number"
+    echo -e "    Show version number"
     echo
     # :command.usage_flags
     # :flag.usage
@@ -105,7 +105,7 @@ cli_upload_usage() {
     echo "    Password to use for logging in"
     echo
     # :command.usage_args
-    echo "Arguments::"
+    echo -e "Arguments:"
     
     # :argument.usage
     echo "  SOURCE"
@@ -192,13 +192,13 @@ parse_args() {
     case "$key" in
   
     -* )
-      echo "invalid option: $key"
+      echo -e "invalid option: $key"
       exit 1
       ;;
   
     * )
       # :command.parse_args_case
-      echo "invalid argument: $key"
+      echo -e "invalid argument: $key"
       exit 1
       ;;
   
@@ -244,7 +244,7 @@ download_parse_args() {
   
   
     -* )
-      echo "invalid option: $key"
+      echo -e "invalid option: $key"
       exit 1
       ;;
   
@@ -257,7 +257,7 @@ download_parse_args() {
         args[target]=$1
         shift
       else
-        echo "invalid argument: $key"
+        echo -e "invalid argument: $key"
         exit 1
       fi
       ;;
@@ -294,7 +294,7 @@ upload_parse_args() {
   # :command.required_flags_filter
   argstring="$*"
   if [[ "$argstring" != *--user* && "$argstring" != *-u* ]]; then
-    echo "missing required flag: --user, -u USER"
+    echo -e "missing required flag: --user, -u USER"
     exit 1
   fi
   # :command.parse_args_while
@@ -308,7 +308,7 @@ upload_parse_args() {
         shift
         shift
       else
-        echo "--user requires an argument: --user, -u USER"
+        echo -e "--user requires an argument: --user, -u USER"
         exit 1
       fi
       ;;
@@ -320,14 +320,14 @@ upload_parse_args() {
         shift
         shift
       else
-        echo "--password requires an argument: --password, -p PASSWORD"
+        echo -e "--password requires an argument: --password, -p PASSWORD"
         exit 1
       fi
       ;;
   
   
     -* )
-      echo "invalid option: $key"
+      echo -e "invalid option: $key"
       exit 1
       ;;
   
@@ -337,7 +337,7 @@ upload_parse_args() {
         args[source]=$1
         shift
       else
-        echo "invalid argument: $key"
+        echo -e "invalid argument: $key"
         exit 1
       fi
       ;;

--- a/examples/subcommands/cli
+++ b/examples/subcommands/cli
@@ -16,13 +16,13 @@ cli_usage() {
   echo "  cli [command] [options]"
   echo
   # :command.usage_commands
-  echo "Commands:"
+  echo "Commands::"
   echo "  download   Download a file"
   echo "  upload     Upload a file"
   echo
 
   if [[ -n $long_usage ]]; then
-    echo "Options:"
+    echo "Options::"
     # :command.usage_fixed_flags
     echo "  --help, -h"
     echo "    Show this help"
@@ -46,7 +46,7 @@ cli_download_usage() {
 
 
   if [[ -n $long_usage ]]; then
-    echo "Options:"
+    echo "Options::"
     # :command.usage_fixed_flags
     echo "  --help, -h"
     echo "    Show this help"
@@ -60,7 +60,7 @@ cli_download_usage() {
     echo "    Overwrite existing files"
     echo
     # :command.usage_args
-    echo "Arguments:"
+    echo "Arguments::"
     
     # :argument.usage
     echo "  SOURCE"
@@ -86,7 +86,7 @@ cli_upload_usage() {
 
 
   if [[ -n $long_usage ]]; then
-    echo "Options:"
+    echo "Options::"
     # :command.usage_fixed_flags
     echo "  --help, -h"
     echo "    Show this help"
@@ -105,7 +105,7 @@ cli_upload_usage() {
     echo "    Password to use for logging in"
     echo
     # :command.usage_args
-    echo "Arguments:"
+    echo "Arguments::"
     
     # :argument.usage
     echo "  SOURCE"
@@ -228,8 +228,7 @@ download_parse_args() {
     args[source]=$1
     shift
   else
-    echo "missing required argument: SOURCE"
-    echo "Usage: cli download SOURCE [TARGET] [options]"
+    echo -e "missing required argument: SOURCE\nusage: cli download SOURCE [TARGET] [options]"
     exit 1
   fi
   # :command.required_flags_filter
@@ -289,8 +288,7 @@ upload_parse_args() {
     args[source]=$1
     shift
   else
-    echo "missing required argument: SOURCE"
-    echo "Usage: cli upload SOURCE [options]"
+    echo -e "missing required argument: SOURCE\nusage: cli upload SOURCE [options]"
     exit 1
   fi
   # :command.required_flags_filter

--- a/lib/bashly.rb
+++ b/lib/bashly.rb
@@ -6,8 +6,10 @@ if ENV['BYEBUG']
 end
 
 requires 'bashly/polyfills'
+requires 'bashly/concerns'
+
 requires 'bashly/settings'
 requires 'bashly/exceptions'
-requires 'bashly/concerns'
 requires 'bashly/models/base'
+requires 'bashly/commands/base'
 requires 'bashly'

--- a/lib/bashly/cli.rb
+++ b/lib/bashly/cli.rb
@@ -11,6 +11,7 @@ module Bashly
       runner.route 'init',      to: Commands::Init
       runner.route 'preview',   to: Commands::Preview
       runner.route 'generate',  to: Commands::Generate
+      runner.route 'add',       to: Commands::Add
 
       runner
     end

--- a/lib/bashly/commands/add.rb
+++ b/lib/bashly/commands/add.rb
@@ -1,0 +1,35 @@
+module Bashly
+  module Commands
+    class Add < Base
+      help "Add extra features and customization to your script"
+
+      usage "bashly add strings [--force]"
+      usage "bashly add (-h|--help)"
+
+      option "-f --force", "Overwrite existing files"
+
+      command "strings", "Copy an additional configuration file to your project, allowing you to customize all the tips and error strings."
+
+      environment "BASHLY_SOURCE_DIR", "The path to use for creating the configuration file [default: src]"
+
+      def strings_command
+        safe_copy asset("templates/strings.yml"), "#{Settings.source_dir}/bashly-strings.yml"
+      end
+
+    private
+
+      def safe_copy(source, target)
+        if !Dir.exist? Settings.source_dir
+          raise InitError, "Directory !txtgrn!#{Settings.source_dir}!txtrst! does not exist\nRun !txtpur!bashly init!txtrst! first"
+        end
+
+        if File.exist? target and !args['--force']
+          say "skipped !txtgrn!#{target}!txtrst! (exists)"
+        else
+          FileUtils.cp source, target
+          say "created !txtgrn!#{target}"
+        end
+      end
+    end
+  end
+end

--- a/lib/bashly/commands/base.rb
+++ b/lib/bashly/commands/base.rb
@@ -1,0 +1,10 @@
+require 'mister_bin'
+require 'fileutils'
+
+module Bashly
+  module Commands
+    class Base < MisterBin::Command
+      include AssetHelper
+    end
+  end
+end

--- a/lib/bashly/commands/generate.rb
+++ b/lib/bashly/commands/generate.rb
@@ -1,9 +1,6 @@
-require 'mister_bin'
-require 'fileutils'
-
 module Bashly
   module Commands
-    class Generate < MisterBin::Command
+    class Generate < Base
       help "Generate the bash script and required files"
 
       usage "bashly generate [--force]"

--- a/lib/bashly/commands/init.rb
+++ b/lib/bashly/commands/init.rb
@@ -1,8 +1,6 @@
-require 'mister_bin'
-
 module Bashly
   module Commands
-    class Init < MisterBin::Command
+    class Init < Base
       summary "Initialize a new workspace"
       help "This command will create the source folder, and place a template configuration file in it."
 
@@ -31,18 +29,10 @@ module Bashly
 
       def yaml_content!
         if args['--minimal']
-          File.read minimal_template_file
+          File.read asset('templates/minimal.yml')
         else
-          File.read template_file
+          File.read asset('templates/bashly.yml')
         end
-      end
-
-      def template_file
-        File.expand_path '../templates/bashly.yml', __dir__
-      end
-
-      def minimal_template_file
-        File.expand_path '../templates/minimal.yml', __dir__
       end
 
       def target_dir

--- a/lib/bashly/commands/preview.rb
+++ b/lib/bashly/commands/preview.rb
@@ -1,8 +1,6 @@
-require 'mister_bin'
-
 module Bashly
   module Commands
-    class Preview < MisterBin::Command
+    class Preview < Base
       help "Generate the bash script to STDOUT"
 
       usage "bashly preview"

--- a/lib/bashly/concerns/asset_helper.rb
+++ b/lib/bashly/concerns/asset_helper.rb
@@ -1,0 +1,7 @@
+module Bashly
+  module AssetHelper
+    def asset(path)
+      File.expand_path "../#{path}", __dir__
+    end
+  end
+end

--- a/lib/bashly/concerns/renderable.rb
+++ b/lib/bashly/concerns/renderable.rb
@@ -5,6 +5,10 @@ module Bashly
       ERB.new(template, nil, '%-').result(binding)
     end
 
+    def strings
+      @strings ||= MessageStrings.new
+    end
+
   private
 
     def view_path(view)

--- a/lib/bashly/message_strings.rb
+++ b/lib/bashly/message_strings.rb
@@ -1,0 +1,36 @@
+module Bashly
+  class MessageStrings
+    include AssetHelper
+
+    def [](key)
+      values[key.to_s]
+    end
+
+    def values
+      @values ||= values!
+    end
+
+  private
+
+    def values!
+      defaults = YAML.load_file asset("templates/strings.yml")
+      defaults.merge project_strings
+    end
+
+    def project_strings
+      @project_strings ||= project_strings!
+    end
+
+    def project_strings!
+      if File.exist? project_strings_path
+        YAML.load_file project_strings_path
+      else
+        {}
+      end
+    end
+
+    def project_strings_path
+      @project_strings_path ||= "#{Settings.source_dir}/bashly-strings.yml"
+    end
+  end
+end

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -1,6 +1,7 @@
 module Bashly
   class Settings
     class << self
+      include AssetHelper
       attr_writer :source_dir, :target_dir
 
       def source_dir
@@ -18,7 +19,7 @@ module Bashly
     private
 
       def strings!
-        defaults = YAML.load_file strings_config_path
+        defaults = YAML.load_file asset("templates/strings.yml")
         defaults.merge project_strings
       end
 
@@ -35,11 +36,7 @@ module Bashly
       end
 
       def project_strings_path
-        @project_strings_path ||= "#{source_dir}/bashly-settings.yml"
-      end
-
-      def strings_config_path
-        File.expand_path "templates/strings.yml", __dir__
+        @project_strings_path ||= "#{source_dir}/bashly-strings.yml"
       end
     end
   end

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -10,6 +10,37 @@ module Bashly
       def target_dir
         @target_dir ||= ENV['BASHLY_TARGET_DIR'] || '.'
       end
+
+      def strings
+        @strings ||= strings!
+      end
+
+    private
+
+      def strings!
+        defaults = YAML.load_file strings_config_path
+        defaults.merge project_strings
+      end
+
+      def project_strings
+        @project_strings ||= project_strings!
+      end
+
+      def project_strings!
+        if File.exist? project_strings_path
+          YAML.load_file project_strings_path
+        else
+          {}
+        end
+      end
+
+      def project_strings_path
+        @project_strings_path ||= "#{source_dir}/bashly-settings.yml"
+      end
+
+      def strings_config_path
+        File.expand_path "templates/strings.yml", __dir__
+      end
     end
   end
 end

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -1,7 +1,6 @@
 module Bashly
   class Settings
     class << self
-      include AssetHelper
       attr_writer :source_dir, :target_dir
 
       def source_dir
@@ -10,33 +9,6 @@ module Bashly
 
       def target_dir
         @target_dir ||= ENV['BASHLY_TARGET_DIR'] || '.'
-      end
-
-      def strings
-        @strings ||= strings!
-      end
-
-    private
-
-      def strings!
-        defaults = YAML.load_file asset("templates/strings.yml")
-        defaults.merge project_strings
-      end
-
-      def project_strings
-        @project_strings ||= project_strings!
-      end
-
-      def project_strings!
-        if File.exist? project_strings_path
-          YAML.load_file project_strings_path
-        else
-          {}
-        end
-      end
-
-      def project_strings_path
-        @project_strings_path ||= "#{source_dir}/bashly-strings.yml"
       end
     end
   end

--- a/lib/bashly/templates/strings.yml
+++ b/lib/bashly/templates/strings.yml
@@ -1,0 +1,17 @@
+# Usage captions
+usage: "Usage:"
+options: "Options:"
+arguments: "Arguments:"
+commands: "Commands:"
+
+# Fixed flags help text
+show_this_help: Show this help
+show_version_number: Show version number
+
+# Error messages
+flag_requires_an_argument: "%{long} requires an argument: %{usage}"
+invalid_argument: "invalid argument: %{arg}"
+invalid_flag: "invalid option: %{flag}"
+missing_required_argument: "missing required argument: %{arg}\\nusage: %{usage}"
+missing_required_flag: "missing required flag: %{usage}"
+

--- a/lib/bashly/views/command/parse_args_case.erb
+++ b/lib/bashly/views/command/parse_args_case.erb
@@ -8,10 +8,10 @@
 <%- condition = "elif" -%>
 <%- end -%>
 else
-  echo "invalid argument: $key"
+  echo "<%= Settings.strings["invalid_argument"] % { arg: "$key" } %>"
   exit 1
 fi
 <%- else -%>
-echo "invalid argument: $key"
+echo "<%= Settings.strings["invalid_argument"] % { arg: "$key" } %>"
 exit 1
 <%- end -%>

--- a/lib/bashly/views/command/parse_args_case.erb
+++ b/lib/bashly/views/command/parse_args_case.erb
@@ -8,10 +8,10 @@
 <%- condition = "elif" -%>
 <%- end -%>
 else
-  echo -e "<%= Settings.strings["invalid_argument"] % { arg: "$key" } %>"
+  echo -e "<%= strings["invalid_argument"] % { arg: "$key" } %>"
   exit 1
 fi
 <%- else -%>
-echo -e "<%= Settings.strings["invalid_argument"] % { arg: "$key" } %>"
+echo -e "<%= strings["invalid_argument"] % { arg: "$key" } %>"
 exit 1
 <%- end -%>

--- a/lib/bashly/views/command/parse_args_case.erb
+++ b/lib/bashly/views/command/parse_args_case.erb
@@ -8,10 +8,10 @@
 <%- condition = "elif" -%>
 <%- end -%>
 else
-  echo -e "<%= strings["invalid_argument"] % { arg: "$key" } %>"
+  echo -e "<%= strings[:invalid_argument] % { arg: "$key" } %>"
   exit 1
 fi
 <%- else -%>
-echo -e "<%= strings["invalid_argument"] % { arg: "$key" } %>"
+echo -e "<%= strings[:invalid_argument] % { arg: "$key" } %>"
 exit 1
 <%- end -%>

--- a/lib/bashly/views/command/parse_args_case.erb
+++ b/lib/bashly/views/command/parse_args_case.erb
@@ -8,10 +8,10 @@
 <%- condition = "elif" -%>
 <%- end -%>
 else
-  echo "<%= Settings.strings["invalid_argument"] % { arg: "$key" } %>"
+  echo -e "<%= Settings.strings["invalid_argument"] % { arg: "$key" } %>"
   exit 1
 fi
 <%- else -%>
-echo "<%= Settings.strings["invalid_argument"] % { arg: "$key" } %>"
+echo -e "<%= Settings.strings["invalid_argument"] % { arg: "$key" } %>"
 exit 1
 <%- end -%>

--- a/lib/bashly/views/command/parse_args_while.erb
+++ b/lib/bashly/views/command/parse_args_while.erb
@@ -8,7 +8,7 @@ while [[ $# -gt 0 ]]; do
   <%- end -%>
 
   -* )
-    echo "invalid option: $key"
+    echo "<%= Settings.strings["invalid_flag"] % { flag: "$key" } %>"
     exit 1
     ;;
 

--- a/lib/bashly/views/command/parse_args_while.erb
+++ b/lib/bashly/views/command/parse_args_while.erb
@@ -8,7 +8,7 @@ while [[ $# -gt 0 ]]; do
   <%- end -%>
 
   -* )
-    echo -e "<%= Settings.strings["invalid_flag"] % { flag: "$key" } %>"
+    echo -e "<%= strings["invalid_flag"] % { flag: "$key" } %>"
     exit 1
     ;;
 

--- a/lib/bashly/views/command/parse_args_while.erb
+++ b/lib/bashly/views/command/parse_args_while.erb
@@ -8,7 +8,7 @@ while [[ $# -gt 0 ]]; do
   <%- end -%>
 
   -* )
-    echo -e "<%= strings["invalid_flag"] % { flag: "$key" } %>"
+    echo -e "<%= strings[:invalid_flag] % { flag: "$key" } %>"
     exit 1
     ;;
 

--- a/lib/bashly/views/command/parse_args_while.erb
+++ b/lib/bashly/views/command/parse_args_while.erb
@@ -8,7 +8,7 @@ while [[ $# -gt 0 ]]; do
   <%- end -%>
 
   -* )
-    echo "<%= Settings.strings["invalid_flag"] % { flag: "$key" } %>"
+    echo -e "<%= Settings.strings["invalid_flag"] % { flag: "$key" } %>"
     exit 1
     ;;
 

--- a/lib/bashly/views/command/required_args_filter.erb
+++ b/lib/bashly/views/command/required_args_filter.erb
@@ -4,7 +4,7 @@ if [[ $1 && $1 != -* ]]; then
   args[<%= arg.name %>]=$1
   shift
 else
-  echo -e "<%= Settings.strings["missing_required_argument"] % { arg: arg.name.upcase, usage: usage_string } %>"
+  echo -e "<%= strings["missing_required_argument"] % { arg: arg.name.upcase, usage: usage_string } %>"
   exit 1
 fi
 

--- a/lib/bashly/views/command/required_args_filter.erb
+++ b/lib/bashly/views/command/required_args_filter.erb
@@ -4,8 +4,7 @@ if [[ $1 && $1 != -* ]]; then
   args[<%= arg.name %>]=$1
   shift
 else
-  echo "missing required argument: <%= arg.name.upcase %>"
-  echo "Usage: <%= usage_string %>"
+  echo -e "<%= Settings.strings["missing_required_argument"] % { arg: arg.name.upcase, usage: usage_string } %>"
   exit 1
 fi
 

--- a/lib/bashly/views/command/required_args_filter.erb
+++ b/lib/bashly/views/command/required_args_filter.erb
@@ -4,7 +4,7 @@ if [[ $1 && $1 != -* ]]; then
   args[<%= arg.name %>]=$1
   shift
 else
-  echo -e "<%= strings["missing_required_argument"] % { arg: arg.name.upcase, usage: usage_string } %>"
+  echo -e "<%= strings[:missing_required_argument] % { arg: arg.name.upcase, usage: usage_string } %>"
   exit 1
 fi
 

--- a/lib/bashly/views/command/required_flags_filter.erb
+++ b/lib/bashly/views/command/required_flags_filter.erb
@@ -4,7 +4,7 @@ argstring="$*"
 <%- end -%>
 <%- required_flags.each do |flag| -%>
 if [[ <%= flag.aliases.map { |a| %Q["$argstring" != *#{a}*] }.join " && " %> ]]; then
-  echo "<%= Settings.strings["missing_required_flag"] % { usage: flag.usage_string } %>"
+  echo -e "<%= Settings.strings["missing_required_flag"] % { usage: flag.usage_string } %>"
   exit 1
 fi
 <%- end %>

--- a/lib/bashly/views/command/required_flags_filter.erb
+++ b/lib/bashly/views/command/required_flags_filter.erb
@@ -4,7 +4,7 @@ argstring="$*"
 <%- end -%>
 <%- required_flags.each do |flag| -%>
 if [[ <%= flag.aliases.map { |a| %Q["$argstring" != *#{a}*] }.join " && " %> ]]; then
-  echo "missing required flag: <%= flag.usage_string %>"
+  echo "<%= Settings.strings["missing_required_flag"] % { usage: flag.usage_string } %>"
   exit 1
 fi
 <%- end %>

--- a/lib/bashly/views/command/required_flags_filter.erb
+++ b/lib/bashly/views/command/required_flags_filter.erb
@@ -4,7 +4,7 @@ argstring="$*"
 <%- end -%>
 <%- required_flags.each do |flag| -%>
 if [[ <%= flag.aliases.map { |a| %Q["$argstring" != *#{a}*] }.join " && " %> ]]; then
-  echo -e "<%= Settings.strings["missing_required_flag"] % { usage: flag.usage_string } %>"
+  echo -e "<%= strings["missing_required_flag"] % { usage: flag.usage_string } %>"
   exit 1
 fi
 <%- end %>

--- a/lib/bashly/views/command/required_flags_filter.erb
+++ b/lib/bashly/views/command/required_flags_filter.erb
@@ -4,7 +4,7 @@ argstring="$*"
 <%- end -%>
 <%- required_flags.each do |flag| -%>
 if [[ <%= flag.aliases.map { |a| %Q["$argstring" != *#{a}*] }.join " && " %> ]]; then
-  echo -e "<%= strings["missing_required_flag"] % { usage: flag.usage_string } %>"
+  echo -e "<%= strings[:missing_required_flag] % { usage: flag.usage_string } %>"
   exit 1
 fi
 <%- end %>

--- a/lib/bashly/views/command/usage.erb
+++ b/lib/bashly/views/command/usage.erb
@@ -2,13 +2,13 @@
 <%= full_name.to_underscore %>_usage() {
   echo "<%= caption_string %>"
   echo 
-  echo "Usage:"
+  echo "<%= Settings.strings["usage"] %>"
   echo "  <%= usage_string %>"
   echo
 <%= render(:usage_commands).indent 2 if commands.any? %>
 
   if [[ -n $long_usage ]]; then
-    echo "Options:"
+    echo "<%= Settings.strings["options"] %>:"
 <%= render(:usage_fixed_flags).indent 4 %>
 <%= render(:usage_flags).indent 4 if flags.any? %>
 <%= render(:usage_args).indent 4 if args.any? %>

--- a/lib/bashly/views/command/usage.erb
+++ b/lib/bashly/views/command/usage.erb
@@ -1,14 +1,14 @@
 # :command.usage
 <%= full_name.to_underscore %>_usage() {
-  echo "<%= caption_string %>"
+  echo -e "<%= caption_string %>"
   echo 
-  echo "<%= Settings.strings["usage"] %>"
-  echo "  <%= usage_string %>"
+  echo -e "<%= Settings.strings["usage"] %>"
+  echo -e "  <%= usage_string %>"
   echo
 <%= render(:usage_commands).indent 2 if commands.any? %>
 
   if [[ -n $long_usage ]]; then
-    echo "<%= Settings.strings["options"] %>:"
+    echo -e "<%= Settings.strings["options"] %>"
 <%= render(:usage_fixed_flags).indent 4 %>
 <%= render(:usage_flags).indent 4 if flags.any? %>
 <%= render(:usage_args).indent 4 if args.any? %>

--- a/lib/bashly/views/command/usage.erb
+++ b/lib/bashly/views/command/usage.erb
@@ -2,13 +2,13 @@
 <%= full_name.to_underscore %>_usage() {
   echo -e "<%= caption_string %>"
   echo 
-  echo -e "<%= strings["usage"] %>"
+  echo -e "<%= strings[:usage] %>"
   echo -e "  <%= usage_string %>"
   echo
 <%= render(:usage_commands).indent 2 if commands.any? %>
 
   if [[ -n $long_usage ]]; then
-    echo -e "<%= strings["options"] %>"
+    echo -e "<%= strings[:options] %>"
 <%= render(:usage_fixed_flags).indent 4 %>
 <%= render(:usage_flags).indent 4 if flags.any? %>
 <%= render(:usage_args).indent 4 if args.any? %>

--- a/lib/bashly/views/command/usage.erb
+++ b/lib/bashly/views/command/usage.erb
@@ -2,13 +2,13 @@
 <%= full_name.to_underscore %>_usage() {
   echo -e "<%= caption_string %>"
   echo 
-  echo -e "<%= Settings.strings["usage"] %>"
+  echo -e "<%= strings["usage"] %>"
   echo -e "  <%= usage_string %>"
   echo
 <%= render(:usage_commands).indent 2 if commands.any? %>
 
   if [[ -n $long_usage ]]; then
-    echo -e "<%= Settings.strings["options"] %>"
+    echo -e "<%= strings["options"] %>"
 <%= render(:usage_fixed_flags).indent 4 %>
 <%= render(:usage_flags).indent 4 if flags.any? %>
 <%= render(:usage_args).indent 4 if args.any? %>

--- a/lib/bashly/views/command/usage_args.erb
+++ b/lib/bashly/views/command/usage_args.erb
@@ -1,5 +1,5 @@
 # :command.usage_args
-echo -e "<%= strings["arguments"] %>"
+echo -e "<%= strings[:arguments] %>"
 
 <%- args.each do |arg| -%>
 <%= arg.render(:usage) %>

--- a/lib/bashly/views/command/usage_args.erb
+++ b/lib/bashly/views/command/usage_args.erb
@@ -1,5 +1,5 @@
 # :command.usage_args
-echo "Arguments:"
+echo "<%= Settings.strings["arguments"] %>:"
 
 <%- args.each do |arg| -%>
 <%= arg.render(:usage) %>

--- a/lib/bashly/views/command/usage_args.erb
+++ b/lib/bashly/views/command/usage_args.erb
@@ -1,5 +1,5 @@
 # :command.usage_args
-echo -e "<%= Settings.strings["arguments"] %>"
+echo -e "<%= strings["arguments"] %>"
 
 <%- args.each do |arg| -%>
 <%= arg.render(:usage) %>

--- a/lib/bashly/views/command/usage_args.erb
+++ b/lib/bashly/views/command/usage_args.erb
@@ -1,5 +1,5 @@
 # :command.usage_args
-echo "<%= Settings.strings["arguments"] %>:"
+echo -e "<%= Settings.strings["arguments"] %>"
 
 <%- args.each do |arg| -%>
 <%= arg.render(:usage) %>

--- a/lib/bashly/views/command/usage_commands.erb
+++ b/lib/bashly/views/command/usage_commands.erb
@@ -1,5 +1,5 @@
 # :command.usage_commands
-echo "Commands:"
+echo "<%= Settings.strings["commands"] %>:"
 <%- maxlen = command_names.map(&:size).max -%>
 <%- commands.each do |command| -%>
 echo "  <%= command.name.ljust maxlen %>   <%= command.summary  %>"

--- a/lib/bashly/views/command/usage_commands.erb
+++ b/lib/bashly/views/command/usage_commands.erb
@@ -1,7 +1,7 @@
 # :command.usage_commands
-echo "<%= Settings.strings["commands"] %>:"
+echo -e "<%= Settings.strings["commands"] %>"
 <%- maxlen = command_names.map(&:size).max -%>
 <%- commands.each do |command| -%>
-echo "  <%= command.name.ljust maxlen %>   <%= command.summary  %>"
+echo "  <%= command.name.ljust maxlen %>   <%= command.summary %>"
 <%- end -%>
 echo

--- a/lib/bashly/views/command/usage_commands.erb
+++ b/lib/bashly/views/command/usage_commands.erb
@@ -1,5 +1,5 @@
 # :command.usage_commands
-echo -e "<%= strings["commands"] %>"
+echo -e "<%= strings[:commands] %>"
 <%- maxlen = command_names.map(&:size).max -%>
 <%- commands.each do |command| -%>
 echo "  <%= command.name.ljust maxlen %>   <%= command.summary %>"

--- a/lib/bashly/views/command/usage_commands.erb
+++ b/lib/bashly/views/command/usage_commands.erb
@@ -1,5 +1,5 @@
 # :command.usage_commands
-echo -e "<%= Settings.strings["commands"] %>"
+echo -e "<%= strings["commands"] %>"
 <%- maxlen = command_names.map(&:size).max -%>
 <%- commands.each do |command| -%>
 echo "  <%= command.name.ljust maxlen %>   <%= command.summary %>"

--- a/lib/bashly/views/command/usage_fixed_flags.erb
+++ b/lib/bashly/views/command/usage_fixed_flags.erb
@@ -1,7 +1,7 @@
 # :command.usage_fixed_flags
 echo "  --help, -h"
-echo "    <%= Settings.strings["show_this_help"] %>"
+echo -e "    <%= Settings.strings["show_this_help"] %>"
 echo
 echo "  --version"
-echo "    <%= Settings.strings["show_version_number"] %>"
+echo -e "    <%= Settings.strings["show_version_number"] %>"
 echo

--- a/lib/bashly/views/command/usage_fixed_flags.erb
+++ b/lib/bashly/views/command/usage_fixed_flags.erb
@@ -1,7 +1,7 @@
 # :command.usage_fixed_flags
 echo "  --help, -h"
-echo "    Show this help"
+echo "    <%= Settings.strings["show_this_help"] %>"
 echo
 echo "  --version"
-echo "    Show version number"
+echo "    <%= Settings.strings["show_version_number"] %>"
 echo

--- a/lib/bashly/views/command/usage_fixed_flags.erb
+++ b/lib/bashly/views/command/usage_fixed_flags.erb
@@ -1,7 +1,7 @@
 # :command.usage_fixed_flags
 echo "  --help, -h"
-echo -e "    <%= Settings.strings["show_this_help"] %>"
+echo -e "    <%= strings["show_this_help"] %>"
 echo
 echo "  --version"
-echo -e "    <%= Settings.strings["show_version_number"] %>"
+echo -e "    <%= strings["show_version_number"] %>"
 echo

--- a/lib/bashly/views/command/usage_fixed_flags.erb
+++ b/lib/bashly/views/command/usage_fixed_flags.erb
@@ -1,7 +1,7 @@
 # :command.usage_fixed_flags
 echo "  --help, -h"
-echo -e "    <%= strings["show_this_help"] %>"
+echo -e "    <%= strings[:show_this_help] %>"
 echo
 echo "  --version"
-echo -e "    <%= strings["show_version_number"] %>"
+echo -e "    <%= strings[:show_version_number] %>"
 echo

--- a/lib/bashly/views/flag/case.erb
+++ b/lib/bashly/views/flag/case.erb
@@ -6,7 +6,7 @@
     shift
     shift
   else
-    echo -e "<%= strings["flag_requires_an_argument"] % { long: long, usage: usage_string } %>"
+    echo -e "<%= strings[:flag_requires_an_argument] % { long: long, usage: usage_string } %>"
     exit 1
   fi
   <%- else -%>

--- a/lib/bashly/views/flag/case.erb
+++ b/lib/bashly/views/flag/case.erb
@@ -6,7 +6,7 @@
     shift
     shift
   else
-    echo -e "<%= Settings.strings["flag_requires_an_argument"] % { long: long, usage: usage_string } %>"
+    echo -e "<%= strings["flag_requires_an_argument"] % { long: long, usage: usage_string } %>"
     exit 1
   fi
   <%- else -%>

--- a/lib/bashly/views/flag/case.erb
+++ b/lib/bashly/views/flag/case.erb
@@ -6,7 +6,7 @@
     shift
     shift
   else
-    echo "<%= Settings.strings["flag_requires_an_argument"] % { long: long, usage: usage_string } %>"
+    echo -e "<%= Settings.strings["flag_requires_an_argument"] % { long: long, usage: usage_string } %>"
     exit 1
   fi
   <%- else -%>

--- a/lib/bashly/views/flag/case.erb
+++ b/lib/bashly/views/flag/case.erb
@@ -6,7 +6,7 @@
     shift
     shift
   else
-    echo "<%= long %> requires an argument: <%= usage_string %>"
+    echo "<%= Settings.strings["flag_requires_an_argument"] % { long: long, usage: usage_string } %>"
     exit 1
   fi
   <%- else -%>

--- a/spec/approvals/cli/add/help
+++ b/spec/approvals/cli/add/help
@@ -1,0 +1,21 @@
+Add extra features and customization to your script
+
+Usage:
+  bashly add strings [--force]
+  bashly add (-h|--help)
+
+Commands:
+  strings
+    Copy an additional configuration file to your project, allowing you to
+    customize all the tips and error strings.
+
+Options:
+  -f --force
+    Overwrite existing files
+
+  -h --help
+    Show this help
+
+Environment Variables:
+  BASHLY_SOURCE_DIR
+    The path to use for creating the configuration file [default: src]

--- a/spec/approvals/cli/add/strings
+++ b/spec/approvals/cli/add/strings
@@ -1,0 +1,2 @@
+created [0;32mspec/tmp/src/bashly-strings.yml
+[0m

--- a/spec/approvals/cli/add/strings-exist
+++ b/spec/approvals/cli/add/strings-exist
@@ -1,0 +1,1 @@
+skipped [0;32mspec/tmp/src/bashly-strings.yml[0m (exists)

--- a/spec/approvals/cli/commands
+++ b/spec/approvals/cli/commands
@@ -4,3 +4,4 @@ Commands:
   [1;32minit      [0mInitialize a new workspace
   [1;32mpreview   [0mGenerate the bash script to STDOUT
   [1;32mgenerate  [0mGenerate the bash script and required files
+  [1;32madd       [0mAdd extra features and customization to your script

--- a/spec/approvals/cli/generate/usage
+++ b/spec/approvals/cli/generate/usage
@@ -1,0 +1,3 @@
+Usage:
+  bashly add strings [--force]
+  bashly add (-h|--help)

--- a/spec/approvals/examples/custom-strings
+++ b/spec/approvals/examples/custom-strings
@@ -1,0 +1,36 @@
++ rm -f ./src/root_command.sh
++ bashly generate
+creating user files in [0;32msrc
+[0mcreated [0;32msrc/root_command.sh
+[0mcreated [0;32m./download
+[0mrun [0;35m./download --help[0m to test your bash script
++ ./download
+Boom! a required argument is missing: SOURCE
+usage: download SOURCE [options]
++ ./download -h
+download - Sample minimal application with custom strings
+
+== Usage ==
+
+  download SOURCE [options]
+
+== Options ==
+
+  --help, -h
+    Show this helpful help
+
+  --version
+    Show version number
+
+  --out, -o DIR (required)
+    Target directory
+
+== Arguments ==
+    
+  SOURCE
+    URL to download from
+
++ ./download somesource
+Yo! you forgot a flag: --out, -o DIR
++ ./download somesource -o
+Hey! the flag --out requires an argument: --out, -o DIR

--- a/spec/approvals/examples/minimal
+++ b/spec/approvals/examples/minimal
@@ -6,7 +6,7 @@ creating user files in [0;32msrc
 [0mrun [0;35m./download --help[0m to test your bash script
 + ./download
 missing required argument: SOURCE
-Usage: download SOURCE [TARGET] [options]
+usage: download SOURCE [TARGET] [options]
 + ./download -h
 download - Sample minimal application without subcommands
 

--- a/spec/approvals/examples/subcommands
+++ b/spec/approvals/examples/subcommands
@@ -59,7 +59,7 @@ Arguments:
 
 + ./cli download
 missing required argument: SOURCE
-Usage: cli download SOURCE [TARGET] [options]
+usage: cli download SOURCE [TARGET] [options]
 + ./cli download sourcefile targetfile -f
 # this file is located in 'src/cli_download_command.sh'
 # code for 'cli download' goes here

--- a/spec/bashly/commands/add_spec.rb
+++ b/spec/bashly/commands/add_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Commands::Add do
+  let(:source_dir) { Settings.source_dir }
+  let(:target_dir) { Settings.target_dir }
+  subject { CLI.runner }
+
+  context "with --help" do
+    it "shows long usage" do
+      expect{ subject.run %w[add --help] }.to output_fixture('cli/add/help')
+    end
+  end
+
+  context "without arguments" do
+    it "shows long usage" do
+      expect{ subject.run %w[add] }.to output_fixture('cli/generate/usage')
+    end
+  end
+
+  context "with strings command" do
+    let(:strings_file) { "#{source_dir}/bashly-strings.yml" }
+
+    before do
+      reset_tmp_dir create_src: true
+    end
+
+    it "copies the strings configuration to the user space" do
+      expect { subject.run %w[add strings] }.to output_fixture('cli/add/strings')
+      expect(File).to exist(strings_file)
+    end
+
+    context "when the source directory does not exist" do
+      before do
+        reset_tmp_dir
+      end
+
+      it "raises an error" do
+        expect { subject.run %w[add strings] }.to raise_error(InitError, /does not exist/)
+      end
+    end
+
+    context "when the file exists" do
+      it "skips copying it" do
+        expect { subject.run %w[add strings] }.to output_fixture('cli/add/strings')
+        expect { subject.run %w[add strings] }.to output_fixture('cli/add/strings-exist')
+      end
+    end
+  end
+
+end

--- a/spec/bashly/integration/script_spec.rb
+++ b/spec/bashly/integration/script_spec.rb
@@ -8,6 +8,8 @@ require 'spec_helper'
 describe 'generated bash scripts' do
   examples = Dir["examples/*"].select { |f| File.directory? f }
 
+  leeway = ENV['CI'] ? 40 : 0
+
   examples.each do |example|
     describe example do
       it "works" do
@@ -15,9 +17,12 @@ describe 'generated bash scripts' do
         Dir.chdir example do
           output = `bash test.sh 2>&1`
         end
-        # test with .diff, to allow some variations betwen different machines
-        # (i.e. CI)
-        expect(output).to match_fixture(example).diff(40)
+        
+        # Use .diff to give CI some leeway, since its shell differs soemtimes
+        # This was observed in at least these two cases:
+        # - The "+ ..." shell messages driven by `set -x` have no space
+        # - The order of our `inspect_args` sometimes differs
+        expect(output).to match_fixture(example).diff(leeway)
       end
     end
   end

--- a/spec/bashly/message_strings_spec.rb
+++ b/spec/bashly/message_strings_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe MessageStrings do
+  describe '[]' do
+    it "returns a default string for use in the generated bash" do
+      expect(subject[:usage]).to eq "Usage:"
+    end
+  end
+
+  context "when there is an override user configuration file" do
+    let(:config_template) { "examples/custom-strings/src/bashly-strings.yml" }
+    let(:userspace) { Settings.source_dir }
+
+    before do
+      reset_tmp_dir create_src: true
+      success = system "cp #{config_template} #{userspace}"
+      expect(success).to be true
+    end
+
+    it "returns values from the user config, falling back to defaults" do
+      expect(subject[:usage]).to eq "== Usage ==\n"      
+    end
+  end
+end

--- a/spec/spec_mixin.rb
+++ b/spec/spec_mixin.rb
@@ -1,6 +1,7 @@
 module SpecMixin
-  def reset_tmp_dir
+  def reset_tmp_dir(create_src: false)
     system 'rm -rf spec/tmp/*'
     system 'mkdir -p spec/tmp'
+    system 'mkdir -p spec/tmp/src' if create_src
   end
 end


### PR DESCRIPTION
This started as a custom strings PR and evolved a little, so:

### Improvements:

- [x] Extract all hardcoded strings to a locale-like config, customizable by the user - closes #5 
- [x] Add custom-strings example
- [x] Change many bash `echo` to `echo -e` to allow the user to apply newlines and more
- [x] Add `bashly add strings` command, which will copy the strings config to the user space. This command will be the home for additional goodies that can be added to the project.
- [x] Extracted base command to a base class
- [x] Add `AssetHelper` module, to help replace all those `File.expand_path` to find things we need to copy.
- [x] Improve integration tests by disabling leeway diff unless we are on CI.

### Todo:

- [x] Back to 100% coverage
