### PR TITLE
Fix --version to exit with 0

### DIFF
--- a/examples/colors/colorly
+++ b/examples/colors/colorly
@@ -106,7 +106,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/command-default/ftp
+++ b/examples/command-default/ftp
@@ -144,7 +144,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -217,7 +217,7 @@ ftp_upload_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -271,7 +271,7 @@ ftp_download_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/command-groups/ftp
+++ b/examples/command-groups/ftp
@@ -209,7 +209,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -290,7 +290,7 @@ ftp_download_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -344,7 +344,7 @@ ftp_upload_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -398,7 +398,7 @@ ftp_login_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -440,7 +440,7 @@ ftp_logout_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/commands-nested/cli
+++ b/examples/commands-nested/cli
@@ -293,7 +293,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -360,7 +360,7 @@ cli_dir_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -427,7 +427,7 @@ cli_dir_list_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -481,7 +481,7 @@ cli_dir_remove_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -541,7 +541,7 @@ cli_file_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -608,7 +608,7 @@ cli_file_show_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -662,7 +662,7 @@ cli_file_edit_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/commands/cli
+++ b/examples/commands/cli
@@ -183,7 +183,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -250,7 +250,7 @@ cli_download_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -313,7 +313,7 @@ cli_upload_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/config-ini/configly
+++ b/examples/config-ini/configly
@@ -316,7 +316,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -390,7 +390,7 @@ configly_set_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -455,7 +455,7 @@ configly_get_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -509,7 +509,7 @@ configly_list_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/custom-includes/download
+++ b/examples/custom-includes/download
@@ -78,7 +78,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/custom-strings/download
+++ b/examples/custom-strings/download
@@ -70,7 +70,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/dependencies/cli
+++ b/examples/dependencies/cli
@@ -122,7 +122,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -189,7 +189,7 @@ cli_download_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -239,7 +239,7 @@ cli_upload_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/docker-like/docker
+++ b/examples/docker-like/docker
@@ -241,7 +241,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -308,7 +308,7 @@ docker_container_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -375,7 +375,7 @@ docker_container_run_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -429,7 +429,7 @@ docker_container_stop_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -483,7 +483,7 @@ docker_image_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -543,7 +543,7 @@ docker_image_ls_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/environment-variables/cli
+++ b/examples/environment-variables/cli
@@ -109,7 +109,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -169,7 +169,7 @@ cli_verify_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/git-like/git
+++ b/examples/git-like/git
@@ -138,7 +138,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -205,7 +205,7 @@ git_status_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -247,7 +247,7 @@ git_commit_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/minimal/download
+++ b/examples/minimal/download
@@ -82,7 +82,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/minus-v/cli
+++ b/examples/minus-v/cli
@@ -68,7 +68,7 @@ parse_requirements() {
   case "$1" in
   --version )
     version_command
-    exit 1
+    exit
     ;;
   
   --help )

--- a/examples/multiline/multi
+++ b/examples/multiline/multi
@@ -159,7 +159,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -226,7 +226,7 @@ multi_multiline_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -279,7 +279,7 @@ multi_regular_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/examples/yaml/yaml
+++ b/examples/yaml/yaml
@@ -136,7 +136,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/lib/bashly/views/command/fixed_flags_filter.erb
+++ b/lib/bashly/views/command/fixed_flags_filter.erb
@@ -6,7 +6,7 @@ case "$1" in
 --version | -v )
 <%- end -%>
   version_command
-  exit 1
+  exit
   ;;
 
 <%- if short_flag_exist? "-h" -%>


### PR DESCRIPTION
Generated scripts had their `--version` command exit with 1. 
It seems to be the standard to exit with 0 instead.