### PR TITLE
Hide [options] unless flags are defined

### DIFF
--- a/examples/colors/colorly
+++ b/examples/colors/colorly
@@ -31,7 +31,7 @@ colorly_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  colorly [MESSAGE] [options]\n"
+  printf "  colorly [MESSAGE]\n"
   printf "  colorly --help | -h\n"
   printf "  colorly --version | -v\n"
   echo

--- a/examples/command-default/ftp
+++ b/examples/command-default/ftp
@@ -18,7 +18,7 @@ ftp_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  ftp [command] [options]\n"
+  printf "  ftp [command]\n"
   printf "  ftp [command] --help | -h\n"
   printf "  ftp --version | -v\n"
   echo
@@ -55,7 +55,7 @@ ftp_upload_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  ftp upload SOURCE [options]\n"
+  printf "  ftp upload SOURCE\n"
   printf "  ftp upload --help | -h\n"
   echo
 
@@ -91,7 +91,7 @@ ftp_download_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  ftp download SOURCE [options]\n"
+  printf "  ftp download SOURCE\n"
   printf "  ftp download --help | -h\n"
   echo
 
@@ -237,7 +237,7 @@ ftp_upload_parse_requirements() {
     args[source]=$1
     shift
   else
-    printf "missing required argument: SOURCE\nusage: ftp upload SOURCE [options]\n"
+    printf "missing required argument: SOURCE\nusage: ftp upload SOURCE\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -292,7 +292,7 @@ ftp_download_parse_requirements() {
     args[source]=$1
     shift
   else
-    printf "missing required argument: SOURCE\nusage: ftp download SOURCE [options]\n"
+    printf "missing required argument: SOURCE\nusage: ftp download SOURCE\n"
     exit 1
   fi
   # :command.required_flags_filter

--- a/examples/command-groups/ftp
+++ b/examples/command-groups/ftp
@@ -18,7 +18,7 @@ ftp_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  ftp [command] [options]\n"
+  printf "  ftp [command]\n"
   printf "  ftp [command] --help | -h\n"
   printf "  ftp --version | -v\n"
   echo
@@ -55,7 +55,7 @@ ftp_download_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  ftp download FILE [options]\n"
+  printf "  ftp download FILE\n"
   printf "  ftp download --help | -h\n"
   echo
 
@@ -88,7 +88,7 @@ ftp_upload_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  ftp upload FILE [options]\n"
+  printf "  ftp upload FILE\n"
   printf "  ftp upload --help | -h\n"
   echo
 
@@ -121,7 +121,7 @@ ftp_login_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  ftp login [options]\n"
+  printf "  ftp login\n"
   printf "  ftp login --help | -h\n"
   echo
 
@@ -146,7 +146,7 @@ ftp_logout_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  ftp logout [options]\n"
+  printf "  ftp logout\n"
   printf "  ftp logout --help | -h\n"
   echo
 
@@ -310,7 +310,7 @@ ftp_download_parse_requirements() {
     args[file]=$1
     shift
   else
-    printf "missing required argument: FILE\nusage: ftp download FILE [options]\n"
+    printf "missing required argument: FILE\nusage: ftp download FILE\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -365,7 +365,7 @@ ftp_upload_parse_requirements() {
     args[file]=$1
     shift
   else
-    printf "missing required argument: FILE\nusage: ftp upload FILE [options]\n"
+    printf "missing required argument: FILE\nusage: ftp upload FILE\n"
     exit 1
   fi
   # :command.required_flags_filter

--- a/examples/commands-nested/cli
+++ b/examples/commands-nested/cli
@@ -18,7 +18,7 @@ cli_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  cli [command] [options]\n"
+  printf "  cli [command]\n"
   printf "  cli [command] --help | -h\n"
   printf "  cli --version | -v\n"
   echo
@@ -55,7 +55,7 @@ cli_dir_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  cli dir [command] [options]\n"
+  printf "  cli dir [command]\n"
   printf "  cli dir [command] --help | -h\n"
   echo
   # :command.usage_commands
@@ -85,7 +85,7 @@ cli_dir_list_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  cli dir list PATH [options]\n"
+  printf "  cli dir list PATH\n"
   printf "  cli dir list --help | -h\n"
   echo
 
@@ -158,7 +158,7 @@ cli_file_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  cli file [command] [options]\n"
+  printf "  cli file [command]\n"
   printf "  cli file [command] --help | -h\n"
   echo
   # :command.usage_commands
@@ -188,7 +188,7 @@ cli_file_show_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  cli file show PATH [options]\n"
+  printf "  cli file show PATH\n"
   printf "  cli file show --help | -h\n"
   echo
 
@@ -221,7 +221,7 @@ cli_file_edit_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  cli file edit PATH [options]\n"
+  printf "  cli file edit PATH\n"
   printf "  cli file edit --help | -h\n"
   echo
 
@@ -448,7 +448,7 @@ cli_dir_list_parse_requirements() {
     args[path]=$1
     shift
   else
-    printf "missing required argument: PATH\nusage: cli dir list PATH [options]\n"
+    printf "missing required argument: PATH\nusage: cli dir list PATH\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -632,7 +632,7 @@ cli_file_show_parse_requirements() {
     args[path]=$1
     shift
   else
-    printf "missing required argument: PATH\nusage: cli file show PATH [options]\n"
+    printf "missing required argument: PATH\nusage: cli file show PATH\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -687,7 +687,7 @@ cli_file_edit_parse_requirements() {
     args[path]=$1
     shift
   else
-    printf "missing required argument: PATH\nusage: cli file edit PATH [options]\n"
+    printf "missing required argument: PATH\nusage: cli file edit PATH\n"
     exit 1
   fi
   # :command.required_flags_filter

--- a/examples/commands/cli
+++ b/examples/commands/cli
@@ -18,7 +18,7 @@ cli_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  cli [command] [options]\n"
+  printf "  cli [command]\n"
   printf "  cli [command] --help | -h\n"
   printf "  cli --version | -v\n"
   echo

--- a/examples/config-ini/configly
+++ b/examples/config-ini/configly
@@ -18,7 +18,7 @@ configly_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  configly [command] [options]\n"
+  printf "  configly [command]\n"
   printf "  configly [command] --help | -h\n"
   printf "  configly --version | -v\n"
   echo
@@ -56,7 +56,7 @@ configly_set_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  configly set KEY VALUE [options]\n"
+  printf "  configly set KEY VALUE\n"
   printf "  configly set --help | -h\n"
   echo
 
@@ -103,7 +103,7 @@ configly_get_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  configly get KEY [options]\n"
+  printf "  configly get KEY\n"
   printf "  configly get --help | -h\n"
   echo
 
@@ -145,7 +145,7 @@ configly_list_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  configly list [options]\n"
+  printf "  configly list\n"
   printf "  configly list --help | -h\n"
   echo
 
@@ -410,7 +410,7 @@ configly_set_parse_requirements() {
     args[key]=$1
     shift
   else
-    printf "missing required argument: KEY\nusage: configly set KEY VALUE [options]\n"
+    printf "missing required argument: KEY\nusage: configly set KEY VALUE\n"
     exit 1
   fi
   
@@ -418,7 +418,7 @@ configly_set_parse_requirements() {
     args[value]=$1
     shift
   else
-    printf "missing required argument: VALUE\nusage: configly set KEY VALUE [options]\n"
+    printf "missing required argument: VALUE\nusage: configly set KEY VALUE\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -476,7 +476,7 @@ configly_get_parse_requirements() {
     args[key]=$1
     shift
   else
-    printf "missing required argument: KEY\nusage: configly get KEY [options]\n"
+    printf "missing required argument: KEY\nusage: configly get KEY\n"
     exit 1
   fi
   # :command.required_flags_filter

--- a/examples/custom-includes/download
+++ b/examples/custom-includes/download
@@ -27,7 +27,7 @@ download_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  download [SOURCE] [options]\n"
+  printf "  download [SOURCE]\n"
   printf "  download --help | -h\n"
   printf "  download --version | -v\n"
   echo

--- a/examples/dependencies/cli
+++ b/examples/dependencies/cli
@@ -18,7 +18,7 @@ cli_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  cli [command] [options]\n"
+  printf "  cli [command]\n"
   printf "  cli [command] --help | -h\n"
   printf "  cli --version | -v\n"
   echo
@@ -52,7 +52,7 @@ cli_download_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  cli download [options]\n"
+  printf "  cli download\n"
   printf "  cli download --help | -h\n"
   echo
 
@@ -77,7 +77,7 @@ cli_upload_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  cli upload [options]\n"
+  printf "  cli upload\n"
   printf "  cli upload --help | -h\n"
   echo
 

--- a/examples/docker-like/docker
+++ b/examples/docker-like/docker
@@ -18,7 +18,7 @@ docker_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  docker [command] [options]\n"
+  printf "  docker [command]\n"
   printf "  docker [command] --help | -h\n"
   printf "  docker --version | -v\n"
   echo
@@ -55,7 +55,7 @@ docker_container_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  docker container [command] [options]\n"
+  printf "  docker container [command]\n"
   printf "  docker container [command] --help | -h\n"
   echo
   # :command.usage_commands
@@ -85,7 +85,7 @@ docker_container_run_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  docker container run IMAGE [options]\n"
+  printf "  docker container run IMAGE\n"
   printf "  docker container run --help | -h\n"
   echo
 
@@ -118,7 +118,7 @@ docker_container_stop_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  docker container stop CONTAINER [options]\n"
+  printf "  docker container stop CONTAINER\n"
   printf "  docker container stop --help | -h\n"
   echo
 
@@ -154,7 +154,7 @@ docker_image_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  docker image [command] [options]\n"
+  printf "  docker image [command]\n"
   printf "  docker image [command] --help | -h\n"
   echo
   # :command.usage_commands
@@ -186,7 +186,7 @@ docker_image_ls_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  docker image ls [options]\n"
+  printf "  docker image ls\n"
   printf "  docker image ls --help | -h\n"
   echo
 
@@ -396,7 +396,7 @@ docker_container_run_parse_requirements() {
     args[image]=$1
     shift
   else
-    printf "missing required argument: IMAGE\nusage: docker container run IMAGE [options]\n"
+    printf "missing required argument: IMAGE\nusage: docker container run IMAGE\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -451,7 +451,7 @@ docker_container_stop_parse_requirements() {
     args[container]=$1
     shift
   else
-    printf "missing required argument: CONTAINER\nusage: docker container stop CONTAINER [options]\n"
+    printf "missing required argument: CONTAINER\nusage: docker container stop CONTAINER\n"
     exit 1
   fi
   # :command.required_flags_filter

--- a/examples/environment-variables/cli
+++ b/examples/environment-variables/cli
@@ -18,7 +18,7 @@ cli_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  cli [command] [options]\n"
+  printf "  cli [command]\n"
   printf "  cli [command] --help | -h\n"
   printf "  cli --version | -v\n"
   echo
@@ -62,7 +62,7 @@ cli_verify_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  cli verify [options]\n"
+  printf "  cli verify\n"
   printf "  cli verify --help | -h\n"
   echo
 

--- a/examples/git-like/git
+++ b/examples/git-like/git
@@ -18,7 +18,7 @@ git_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  git [command] [options]\n"
+  printf "  git [command]\n"
   printf "  git [command] --help | -h\n"
   printf "  git --version | -v\n"
   echo
@@ -55,7 +55,7 @@ git_status_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  git status [options]\n"
+  printf "  git status\n"
   printf "  git status --help | -h\n"
   echo
 

--- a/examples/multiline/multi
+++ b/examples/multiline/multi
@@ -20,7 +20,7 @@ multi_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  multi [command] [options]\n"
+  printf "  multi [command]\n"
   printf "  multi [command] --help | -h\n"
   printf "  multi --version | -v\n"
   echo
@@ -106,7 +106,7 @@ multi_regular_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  multi regular [REPO] [options]\n"
+  printf "  multi regular [REPO]\n"
   printf "  multi regular --help | -h\n"
   echo
 

--- a/lib/bashly/models/command.rb
+++ b/lib/bashly/models/command.rb
@@ -158,7 +158,7 @@ module Bashly
         args.each do |arg|
           result << arg.usage_string
         end
-        result << "[options]"
+        result << "[options]" unless flags.empty?
         result.join " "
       end
 

--- a/spec/approvals/examples/command-default
+++ b/spec/approvals/examples/command-default
@@ -9,7 +9,7 @@ run ./ftp --help to test your bash script
 ftp - Sample application that uses the default command option
 
 Usage:
-  ftp [command] [options]
+  ftp [command]
   ftp [command] --help | -h
   ftp --version | -v
 
@@ -21,7 +21,7 @@ Commands:
 ftp - Sample application that uses the default command option
 
 Usage:
-  ftp [command] [options]
+  ftp [command]
   ftp [command] --help | -h
   ftp --version | -v
 

--- a/spec/approvals/examples/command-groups
+++ b/spec/approvals/examples/command-groups
@@ -11,7 +11,7 @@ run ./ftp --help to test your bash script
 ftp - Sample application with command grouping
 
 Usage:
-  ftp [command] [options]
+  ftp [command]
   ftp [command] --help | -h
   ftp --version | -v
 
@@ -27,7 +27,7 @@ Login Commands:
 ftp - Sample application with command grouping
 
 Usage:
-  ftp [command] [options]
+  ftp [command]
   ftp [command] --help | -h
   ftp --version | -v
 

--- a/spec/approvals/examples/commands
+++ b/spec/approvals/examples/commands
@@ -9,7 +9,7 @@ run ./cli --help to test your bash script
 cli - Sample application
 
 Usage:
-  cli [command] [options]
+  cli [command]
   cli [command] --help | -h
   cli --version | -v
 
@@ -21,7 +21,7 @@ Commands:
 cli - Sample application
 
 Usage:
-  cli [command] [options]
+  cli [command]
   cli [command] --help | -h
   cli --version | -v
 

--- a/spec/approvals/examples/commands-nested
+++ b/spec/approvals/examples/commands-nested
@@ -11,7 +11,7 @@ run ./cli --help to test your bash script
 cli - Sample application with nested commands
 
 Usage:
-  cli [command] [options]
+  cli [command]
   cli [command] --help | -h
   cli --version | -v
 
@@ -23,7 +23,7 @@ Commands:
 cli - Sample application with nested commands
 
 Usage:
-  cli [command] [options]
+  cli [command]
   cli [command] --help | -h
   cli --version | -v
 
@@ -44,7 +44,7 @@ cli dir - Directory commands
 Shortcut: d
 
 Usage:
-  cli dir [command] [options]
+  cli dir [command]
   cli dir [command] --help | -h
 
 Commands:
@@ -57,7 +57,7 @@ cli file - File commands
 Shortcut: f
 
 Usage:
-  cli file [command] [options]
+  cli file [command]
   cli file [command] --help | -h
 
 Commands:
@@ -70,7 +70,7 @@ cli dir - Directory commands
 Shortcut: d
 
 Usage:
-  cli dir [command] [options]
+  cli dir [command]
   cli dir [command] --help | -h
 
 Commands:
@@ -87,7 +87,7 @@ cli file - File commands
 Shortcut: f
 
 Usage:
-  cli file [command] [options]
+  cli file [command]
   cli file [command] --help | -h
 
 Commands:
@@ -100,12 +100,12 @@ Options:
 
 + ./cli dir list
 missing required argument: PATH
-usage: cli dir list PATH [options]
+usage: cli dir list PATH
 + ./cli dir list -h
 cli dir list - Show files in the directory
 
 Usage:
-  cli dir list PATH [options]
+  cli dir list PATH
   cli dir list --help | -h
 
 Options:
@@ -118,12 +118,12 @@ Arguments:
 
 + ./cli file edit
 missing required argument: PATH
-usage: cli file edit PATH [options]
+usage: cli file edit PATH
 + ./cli file edit -h
 cli file edit - Edit the file
 
 Usage:
-  cli file edit PATH [options]
+  cli file edit PATH
   cli file edit --help | -h
 
 Options:

--- a/spec/approvals/examples/config-ini
+++ b/spec/approvals/examples/config-ini
@@ -10,7 +10,7 @@ run ./configly --help to test your bash script
 configly - Sample application that uses the config functions
 
 Usage:
-  configly [command] [options]
+  configly [command]
   configly [command] --help | -h
   configly --version | -v
 

--- a/spec/approvals/examples/docker-like
+++ b/spec/approvals/examples/docker-like
@@ -10,7 +10,7 @@ run ./docker --help to test your bash script
 docker - Docker example
 
 Usage:
-  docker [command] [options]
+  docker [command]
   docker [command] --help | -h
   docker --version | -v
 
@@ -22,7 +22,7 @@ Commands:
 docker - Docker example
 
 Usage:
-  docker [command] [options]
+  docker [command]
   docker [command] --help | -h
   docker --version | -v
 
@@ -43,7 +43,7 @@ docker container - Container commands
 Shortcut: c*
 
 Usage:
-  docker container [command] [options]
+  docker container [command]
   docker container [command] --help | -h
 
 Commands:
@@ -54,7 +54,7 @@ Commands:
 docker container run - Run a container
 
 Usage:
-  docker container run IMAGE [options]
+  docker container run IMAGE
   docker container run --help | -h
 
 Options:
@@ -67,7 +67,7 @@ Arguments:
 
 + ./docker container run
 missing required argument: IMAGE
-usage: docker container run IMAGE [options]
+usage: docker container run IMAGE
 + ./docker container run alpine
 # this file is located in 'src/container_run_command.sh'
 # code for 'docker container run' goes here
@@ -80,7 +80,7 @@ docker container - Container commands
 Shortcut: c*
 
 Usage:
-  docker container [command] [options]
+  docker container [command]
   docker container [command] --help | -h
 
 Commands:
@@ -93,7 +93,7 @@ docker image - Image commands
 Shortcut: i*
 
 Usage:
-  docker image [command] [options]
+  docker image [command]
   docker image [command] --help | -h
 
 Commands:

--- a/spec/approvals/examples/environment-variables
+++ b/spec/approvals/examples/environment-variables
@@ -8,7 +8,7 @@ run ./cli --help to test your bash script
 cli - Sample application that requires environment variables
 
 Usage:
-  cli [command] [options]
+  cli [command]
   cli [command] --help | -h
   cli --version | -v
 
@@ -19,7 +19,7 @@ Commands:
 cli - Sample application that requires environment variables
 
 Usage:
-  cli [command] [options]
+  cli [command]
   cli [command] --help | -h
   cli --version | -v
 
@@ -43,7 +43,7 @@ cli verify - Verify your user
 Shortcut: v
 
 Usage:
-  cli verify [options]
+  cli verify
   cli verify --help | -h
 
 Options:

--- a/spec/approvals/examples/git-like
+++ b/spec/approvals/examples/git-like
@@ -9,7 +9,7 @@ run ./git --help to test your bash script
 git - Git example
 
 Usage:
-  git [command] [options]
+  git [command]
   git [command] --help | -h
   git --version | -v
 
@@ -21,7 +21,7 @@ Commands:
 git - Git example
 
 Usage:
-  git [command] [options]
+  git [command]
   git [command] --help | -h
   git --version | -v
 
@@ -47,7 +47,7 @@ git status - Show repository status
 Shortcut: s*
 
 Usage:
-  git status [options]
+  git status
   git status --help | -h
 
 Options:

--- a/spec/approvals/examples/multiline
+++ b/spec/approvals/examples/multiline
@@ -9,7 +9,7 @@ run ./multi --help to test your bash script
 multi - Multiline test
 
 Usage:
-  multi [command] [options]
+  multi [command]
   multi [command] --help | -h
   multi --version | -v
 
@@ -26,7 +26,7 @@ multi
   at the 80 character mark.
 
 Usage:
-  multi [command] [options]
+  multi [command]
   multi [command] --help | -h
   multi --version | -v
 

--- a/spec/approvals/examples/short-command-code
+++ b/spec/approvals/examples/short-command-code
@@ -12,4 +12,4 @@ run ./rush --help to test your bash script
 args:
 + ./rush g
 missing required argument: REPO
-usage: rush get REPO [options]
+usage: rush get REPO

--- a/spec/bashly/models/command_spec.rb
+++ b/spec/bashly/models/command_spec.rb
@@ -255,8 +255,16 @@ describe Models::Command do
       let(:fixture) { :git_status }
 
       it "returns a string suitable to be used as a usage pattern" do
-        expect(subject.usage_string).to eq "git status [options]"
+        expect(subject.usage_string).to eq "git status"
       end
+    end
+
+    context "when flags are defined" do
+      let(:fixture) { :flags_only_command }
+
+      it "adds [options] to the usate string" do
+        expect(subject.usage_string).to eq "git status [options]"
+      end      
     end
 
     context "when args are defined" do
@@ -269,7 +277,7 @@ describe Models::Command do
       let(:fixture) { :docker }
 
       it "includes [command] in the usage string" do
-        expect(subject.usage_string).to eq "docker [command] [options]"
+        expect(subject.usage_string).to eq "docker [command]"
       end      
     end
   end

--- a/spec/fixtures/models/commands.yml
+++ b/spec/fixtures/models/commands.yml
@@ -1,4 +1,4 @@
-:basic_command: &default
+:basic_command:
   name: get
   short: g
   help: |-
@@ -43,6 +43,14 @@
 :long_only_command:
   name: get
   help: get something from somewhere
+
+:flags_only_command:
+  name: status
+  help: perform git status
+  flags:
+  - long: --force
+  - long: --verbose
+  parents: [git]
 
 :helpless:
   name: helpless


### PR DESCRIPTION
When there are no flags defined, there is no reason to show `[options]` in the usage string of the command.