### PR TITLE
Add config_has_key to the config stdlib

### DIFF
--- a/examples/config-ini/configly
+++ b/examples/config-ini/configly
@@ -283,6 +283,17 @@ config_keys() {
   echo "${keys[@]}"
 }
 
+# Returns true if the specified key exists in the config file
+# Usage:
+#
+#   if config_has_key "key" ; then
+#     echo "key exists"
+#   fi
+#
+config_has_key() {
+  [[ $(config_get "$1") ]]
+}
+
 # :command.command_functions
 # :command.function
 configly_set_command() {
@@ -296,7 +307,13 @@ configly_set_command() {
 configly_get_command() {
   # :src/get_command.sh
   # Using the standard library (lib/config.sh) to show a value from the config
-  config_get "${args[key]}"
+  
+  key="${args[key]}"
+  if config_has_key "$key" ; then 
+    config_get "$key"
+  else
+    echo "No such key: $key"
+  fi
   
   # Example of how to assign the config value to a variable:
   # result=$(config_get "${args[key]}")

--- a/examples/config-ini/src/get_command.sh
+++ b/examples/config-ini/src/get_command.sh
@@ -1,5 +1,11 @@
 # Using the standard library (lib/config.sh) to show a value from the config
-config_get "${args[key]}"
+
+key="${args[key]}"
+if config_has_key "$key" ; then 
+  config_get "$key"
+else
+  echo "No such key: $key"
+fi
 
 # Example of how to assign the config value to a variable:
 # result=$(config_get "${args[key]}")

--- a/examples/config-ini/src/lib/config.sh
+++ b/examples/config-ini/src/lib/config.sh
@@ -113,3 +113,14 @@ config_keys() {
   done < "$CONFIG_FILE"
   echo "${keys[@]}"
 }
+
+# Returns true if the specified key exists in the config file
+# Usage:
+#
+#   if config_has_key "key" ; then
+#     echo "key exists"
+#   fi
+#
+config_has_key() {
+  [[ $(config_get "$1") ]]
+}

--- a/examples/config-ini/test.sh
+++ b/examples/config-ini/test.sh
@@ -8,4 +8,5 @@ bashly generate
 ./configly set hello world
 ./configly set bashly works
 ./configly get hello
+./configly get invalid_key
 ./configly list

--- a/lib/bashly/templates/lib/config.sh
+++ b/lib/bashly/templates/lib/config.sh
@@ -113,3 +113,14 @@ config_keys() {
   done < "$CONFIG_FILE"
   echo "${keys[@]}"
 }
+
+# Returns true if the specified key exists in the config file
+# Usage:
+#
+#   if config_has_key "key" ; then
+#     echo "key exists"
+#   fi
+#
+config_has_key() {
+  [[ $(config_get "$1") ]]
+}

--- a/spec/approvals/examples/config-ini
+++ b/spec/approvals/examples/config-ini
@@ -32,6 +32,8 @@ saved: hello = world
 saved: bashly = works
 + ./configly get hello
 world
++ ./configly get invalid_key
+No such key: invalid_key
 + ./configly list
 hello = world
 bashly = works


### PR DESCRIPTION
The config standard library (which can be added by running `bashly add config`) now comes with the syntactic sugar function `config_has_key "$key"`. 