### PR TITLE
Config stdlib: allow comments

### DIFF
--- a/examples/config-ini/config.ini
+++ b/examples/config-ini/config.ini
@@ -1,3 +1,4 @@
+; comments are allowed
 hello = world
 bashly = works
 

--- a/examples/config-ini/configly
+++ b/examples/config-ini/configly
@@ -325,6 +325,11 @@ configly_list_command() {
   # :src/list_command.sh
   # Using the standard library (lib/config.sh) to show the entire config file
   config_show
+  
+  # Or to iterate through keys
+  for key in $(config_keys) ; do
+    echo "$key === $(config_get "$key")"
+  done
 }
 
 # :command.parse_requirements

--- a/examples/config-ini/src/list_command.sh
+++ b/examples/config-ini/src/list_command.sh
@@ -1,2 +1,7 @@
 # Using the standard library (lib/config.sh) to show the entire config file
 config_show
+
+# Or to iterate through keys
+for key in $(config_keys) ; do
+  echo "$key === $(config_get "$key")"
+done

--- a/lib/bashly/templates/lib/config.sh
+++ b/lib/bashly/templates/lib/config.sh
@@ -100,7 +100,7 @@ config_show() {
 #   done
 #
 config_keys() {
-  regex="^(.*)\s*="
+  regex="^([a-zA-Z0-9_\-]+)\s*="
 
   config_init
 

--- a/spec/approvals/examples/config-ini
+++ b/spec/approvals/examples/config-ini
@@ -35,6 +35,9 @@ world
 + ./configly get invalid_key
 No such key: invalid_key
 + ./configly list
+; comments are allowed
 hello = world
 bashly = works
 
+hello === world
+bashly === works


### PR DESCRIPTION
Change the `config_keys` function in the config stdlib (`bashly add config`) so that it allows comments. In fact, it will ignore any line that does not start with an alphanumeric / underscore character.