### PR TITLE
Allow using short name only for flags and change '%{long}' in flag translation to '%{name}'

### DIFF
--- a/examples/custom-strings/src/bashly-strings.yml
+++ b/examples/custom-strings/src/bashly-strings.yml
@@ -9,7 +9,7 @@ help_flag_text: Show this helpful help
 version_flag_text: Show version number
 
 # Error messages
-flag_requires_an_argument: "Hey! the flag %{long} requires an argument: %{usage}"
+flag_requires_an_argument: "Hey! the flag %{name} requires an argument: %{usage}"
 missing_required_argument: "Boom! a required argument is missing: %{arg}\\nusage: %{usage}"
 missing_required_flag: "Yo! you forgot a flag: %{usage}"
 

--- a/lib/bashly/models/flag.rb
+++ b/lib/bashly/models/flag.rb
@@ -11,6 +11,10 @@ module Bashly
         end
       end
 
+      def name
+        long || short
+      end
+
       def usage_string(extended: false)
         result = [aliases.join(", ")]
         result << arg.upcase if arg

--- a/lib/bashly/templates/strings.yml
+++ b/lib/bashly/templates/strings.yml
@@ -21,7 +21,7 @@ help_flag_text: Show this help
 version_flag_text: Show version number
 
 # Error messages
-flag_requires_an_argument: "%{long} requires an argument: %{usage}"
+flag_requires_an_argument: "%{name} requires an argument: %{usage}"
 invalid_argument: "invalid argument: %s"
 invalid_flag: "invalid option: %s"
 missing_required_argument: "missing required argument: %{arg}\\nusage: %{usage}"

--- a/lib/bashly/views/flag/case.erb
+++ b/lib/bashly/views/flag/case.erb
@@ -2,15 +2,15 @@
 <%= aliases.join " | " %> )
   <%- if arg -%>
   if [[ $2 && $2 != -* ]]; then
-    args[<%= long %>]="$2"
+    args[<%= name %>]="$2"
     shift
     shift
   else
-    printf "%s\n" "<%= strings[:flag_requires_an_argument] % { long: long, usage: usage_string } %>"
+    printf "%s\n" "<%= strings[:flag_requires_an_argument] % { name: name, usage: usage_string } %>"
     exit 1
   fi
   <%- else -%>
-  args[<%= long %>]=1
+  args[<%= name %>]=1
   shift
   <%- end -%>
   ;;

--- a/spec/bashly/models/flag_spec.rb
+++ b/spec/bashly/models/flag_spec.rb
@@ -26,6 +26,28 @@ describe Models::Flag do
     end
   end
 
+  describe '#name' do
+    context "with both short and long options" do
+      it "returns the long option" do
+        expect(subject.name).to eq "--help"
+      end
+    end
+
+    context "with long option only" do
+      let(:options) { {"long" => "-l"} }
+      it "returns the long option" do
+        expect(subject.name).to eq "-l"
+      end
+    end
+
+    context "with short option only" do
+      let(:options) { {"short" => "-s"} }
+      it "returns the short option" do
+        expect(subject.name).to eq "-s"
+      end
+    end
+  end
+
   describe '#usage_string' do
     it "returns a string suitable to be used as a usage pattern" do
       expect(subject.usage_string).to eq "--help, -h"


### PR DESCRIPTION
Prior to this PR, specifying a short flag only, generated a broken script.

```yaml
flags:
- short: -1
  help: Same as --tail 1
```

This PR fixes it.

Note that for those using custom translations, there is one change. Instead of `%{long}`, use `%{name}` in the `flag_requires_an_argument` key:

```diff
- flag_requires_an_argument: "%{long} requires an argument: %{usage}"
+ flag_requires_an_argument: "%{name} requires an argument: %{usage}"
```
