### PR TITLE
Fix failing specs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['2.4', '2.5', '2.6', '2.7', '3.0'] }
+      matrix: { ruby: ['2.5', '2.6', '2.7', '3.0'] }
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['2.5', '2.6', '2.7', '3.0'] }
+      matrix: { ruby: ['2.4', '2.5', '2.6', '2.7', '3.0'] }
 
     steps:
     - name: Checkout code

--- a/examples/colors/colorly
+++ b/examples/colors/colorly
@@ -59,8 +59,9 @@ colorly_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.user_lib

--- a/examples/colors/colorly
+++ b/examples/colors/colorly
@@ -59,9 +59,13 @@ colorly_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.user_lib

--- a/examples/command-default/ftp
+++ b/examples/command-default/ftp
@@ -115,8 +115,9 @@ ftp_download_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/command-default/ftp
+++ b/examples/command-default/ftp
@@ -115,9 +115,13 @@ ftp_download_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/command-groups/ftp
+++ b/examples/command-groups/ftp
@@ -162,8 +162,9 @@ ftp_logout_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/command-groups/ftp
+++ b/examples/command-groups/ftp
@@ -162,9 +162,13 @@ ftp_logout_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/commands-nested/cli
+++ b/examples/commands-nested/cli
@@ -245,9 +245,13 @@ cli_file_edit_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/commands-nested/cli
+++ b/examples/commands-nested/cli
@@ -245,8 +245,9 @@ cli_file_edit_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/commands/cli
+++ b/examples/commands/cli
@@ -154,9 +154,13 @@ cli_upload_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/commands/cli
+++ b/examples/commands/cli
@@ -154,8 +154,9 @@ cli_upload_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/config-ini/configly
+++ b/examples/config-ini/configly
@@ -161,9 +161,13 @@ configly_list_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.user_lib

--- a/examples/config-ini/configly
+++ b/examples/config-ini/configly
@@ -161,8 +161,9 @@ configly_list_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.user_lib

--- a/examples/custom-includes/download
+++ b/examples/custom-includes/download
@@ -55,9 +55,13 @@ download_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.user_lib

--- a/examples/custom-includes/download
+++ b/examples/custom-includes/download
@@ -55,8 +55,9 @@ download_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.user_lib

--- a/examples/custom-strings/download
+++ b/examples/custom-strings/download
@@ -58,9 +58,13 @@ download_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/custom-strings/download
+++ b/examples/custom-strings/download
@@ -58,8 +58,9 @@ download_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/default-values/convert
+++ b/examples/default-values/convert
@@ -68,8 +68,9 @@ convert_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/default-values/convert
+++ b/examples/default-values/convert
@@ -68,9 +68,13 @@ convert_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/dependencies/cli
+++ b/examples/dependencies/cli
@@ -93,8 +93,9 @@ cli_upload_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/dependencies/cli
+++ b/examples/dependencies/cli
@@ -93,9 +93,13 @@ cli_upload_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/docker-like/docker
+++ b/examples/docker-like/docker
@@ -202,8 +202,9 @@ docker_image_ls_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/docker-like/docker
+++ b/examples/docker-like/docker
@@ -202,9 +202,13 @@ docker_image_ls_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/environment-variables/cli
+++ b/examples/environment-variables/cli
@@ -86,9 +86,13 @@ cli_verify_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/environment-variables/cli
+++ b/examples/environment-variables/cli
@@ -86,8 +86,9 @@ cli_verify_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/git-like/git
+++ b/examples/git-like/git
@@ -109,9 +109,13 @@ git_commit_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/git-like/git
+++ b/examples/git-like/git
@@ -109,8 +109,9 @@ git_commit_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/minimal/download
+++ b/examples/minimal/download
@@ -70,8 +70,9 @@ download_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/minimal/download
+++ b/examples/minimal/download
@@ -70,9 +70,13 @@ download_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/minus-v/cli
+++ b/examples/minus-v/cli
@@ -56,8 +56,9 @@ cli_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/minus-v/cli
+++ b/examples/minus-v/cli
@@ -56,9 +56,13 @@ cli_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/multiline/multi
+++ b/examples/multiline/multi
@@ -130,8 +130,9 @@ multi_regular_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.command_functions

--- a/examples/multiline/multi
+++ b/examples/multiline/multi
@@ -130,9 +130,13 @@ multi_regular_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.command_functions

--- a/examples/yaml/yaml
+++ b/examples/yaml/yaml
@@ -86,8 +86,9 @@ yaml_usage() {
 
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }
 
 # :command.user_lib

--- a/examples/yaml/yaml
+++ b/examples/yaml/yaml
@@ -86,9 +86,13 @@ yaml_usage() {
 
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }
 
 # :command.user_lib

--- a/lib/bashly/views/command/inspect_args.erb
+++ b/lib/bashly/views/command/inspect_args.erb
@@ -1,5 +1,6 @@
 # :command.inspect_args
 inspect_args() {
+  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
   echo args:
-  for k in "${!args[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
 }

--- a/lib/bashly/views/command/inspect_args.erb
+++ b/lib/bashly/views/command/inspect_args.erb
@@ -1,6 +1,10 @@
 # :command.inspect_args
 inspect_args() {
-  keys=( $( echo ${!args[@]} | tr ' ' $'\n' | sort ) )
-  echo args:
-  for k in "${keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
+  if (( ${#args[@]} )); then
+    echo args:
+    for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+  else
+    echo args: none
+  fi
 }

--- a/spec/approvals/examples/command-groups
+++ b/spec/approvals/examples/command-groups
@@ -50,4 +50,4 @@ Options:
 # this file is located in 'src/login_command.sh'
 # code for 'ftp login' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
-args:
+args: none

--- a/spec/approvals/examples/commands
+++ b/spec/approvals/examples/commands
@@ -81,9 +81,9 @@ usage: cli download SOURCE [TARGET] [options]
 # code for 'cli download' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
-- ${args[target]} = targetfile
-- ${args[source]} = sourcefile
 - ${args[--force]} = 1
+- ${args[source]} = sourcefile
+- ${args[target]} = targetfile
 + ./cli upload --help
 cli upload - Upload a file
 

--- a/spec/approvals/examples/default-values
+++ b/spec/approvals/examples/default-values
@@ -8,8 +8,8 @@ run ./convert --help to test your bash script
 # this file is located in 'src/root_command.sh'
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
-- ${args[source]} = *.jpg
 - ${args[--format]} = png
+- ${args[source]} = *.jpg
 + ./convert -h
 convert - Sample application using default arguments and flags
 
@@ -43,17 +43,17 @@ Examples:
 # this file is located in 'src/root_command.sh'
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
-- ${args[source]} = *.bmp
 - ${args[--format]} = png
+- ${args[source]} = *.bmp
 + ./convert -f pdf
 # this file is located in 'src/root_command.sh'
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
-- ${args[source]} = *.jpg
 - ${args[--format]} = pdf
+- ${args[source]} = *.jpg
 + ./convert '*.pdf' --format gif
 # this file is located in 'src/root_command.sh'
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
-- ${args[source]} = *.pdf
 - ${args[--format]} = gif
+- ${args[source]} = *.pdf

--- a/spec/approvals/examples/dependencies
+++ b/spec/approvals/examples/dependencies
@@ -11,4 +11,4 @@ missing dependency: shmurl
 # this file is located in 'src/upload_command.sh'
 # code for 'cli upload' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
-args:
+args: none

--- a/spec/approvals/examples/docker-like
+++ b/spec/approvals/examples/docker-like
@@ -103,9 +103,9 @@ Commands:
 # this file is located in 'src/image_ls_command.sh'
 # code for 'docker image ls' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
-args:
+args: none
 + ./docker i l
 # this file is located in 'src/image_ls_command.sh'
 # code for 'docker image ls' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
-args:
+args: none

--- a/spec/approvals/examples/environment-variables
+++ b/spec/approvals/examples/environment-variables
@@ -61,6 +61,6 @@ missing required environment variable: MY_SECRET
 # this file is located in 'src/verify_command.sh'
 # code for 'cli verify' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
-args:
+args: none
 environment:
 - MY_SECRET=there is no spoon

--- a/spec/approvals/examples/git-like
+++ b/spec/approvals/examples/git-like
@@ -40,7 +40,7 @@ Options:
 # this file is located in 'src/status_command.sh'
 # code for 'git status' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
-args:
+args: none
 + ./git status -h
 git status - Show repository status
 

--- a/spec/approvals/examples/git-like
+++ b/spec/approvals/examples/git-like
@@ -78,5 +78,5 @@ Options:
 # code for 'git commit' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
-- ${args[--message]} = initial commit
 - ${args[--all]} = 1
+- ${args[--message]} = initial commit

--- a/spec/approvals/examples/minimal
+++ b/spec/approvals/examples/minimal
@@ -43,5 +43,5 @@ Examples:
 # this file is located in 'src/root_command.sh'
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
-- ${args[source]} = somesource
 - ${args[--force]} = 1
+- ${args[source]} = somesource

--- a/spec/approvals/examples/minus-v
+++ b/spec/approvals/examples/minus-v
@@ -7,7 +7,7 @@ run ./cli --help to test your bash script
 + ./cli
 # this file is located in 'src/root_command.sh'
 # you can edit it freely and regenerate (it will not be overwritten)
-args:
+args: none
 + ./cli --help
 cli - Example that replaces the default behavior of -v and -h
 

--- a/spec/approvals/examples/multiline
+++ b/spec/approvals/examples/multiline
@@ -57,7 +57,7 @@ Examples:
 # this file is located in 'src/multiline_command.sh'
 # code for 'multi multiline' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
-args:
+args: none
 + ./multi multiline -h
 multi multiline
 

--- a/spec/approvals/examples/short-command-code
+++ b/spec/approvals/examples/short-command-code
@@ -9,7 +9,7 @@ run ./rush --help to test your bash script
 # this file is located in 'src/config_command.sh'
 # code for 'rush config' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
-args:
+args: none
 + ./rush g
 missing required argument: REPO
 usage: rush get REPO

--- a/spec/bashly/integration/examples_spec.rb
+++ b/spec/bashly/integration/examples_spec.rb
@@ -14,7 +14,7 @@ describe 'generated bash scripts' do
 
   test_cases = fixtures + examples
 
-  leeway = ENV['CI'] ? 10 : 0
+  leeway = ENV['CI'] ? 30 : 0
 
   test_cases.each do |example|
     approval_name = example.gsub "spec/fixtures/workspaces", "examples"

--- a/spec/bashly/integration/examples_spec.rb
+++ b/spec/bashly/integration/examples_spec.rb
@@ -14,7 +14,7 @@ describe 'generated bash scripts' do
 
   test_cases = fixtures + examples
 
-  leeway = ENV['CI'] ? 50 : 0
+  leeway = ENV['CI'] ? 10 : 0
 
   test_cases.each do |example|
     approval_name = example.gsub "spec/fixtures/workspaces", "examples"


### PR DESCRIPTION
Order of `args` array in `inspect_args` is different in CI shells.

This PR changes the function to always sort the keys prior to outputting them.
The amount of files changed in this PR is mainly due to regenerated examples and approvals.