### PR TITLE
Refactor completions to allow adding custom functions (like git branches)

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,50 +349,29 @@ functionality to your script in one of three ways:
 
 The bash completions generation is completely automatic, and you will have to 
 rerun the `bashly add comp *` command whenever you change your `bashly.yml` 
-script.
+file.
 
 In addition to suggesting subcommands and flags, you can instruct bashly to
-also suggest files, directories, users and more. To do this, add another option
-in your `bashly.yml` on the command you wish to alter:
+also suggest files, directories, users, git branches and more. To do this,
+add another option in your `bashly.yml` on the command you wish to alter:
 
 ```yaml
 # bashly.yml
 commands:
 - name: upload
   help: Upload a file
-  completions: [directory, user]
+  completions:
+  - <directory>
+  - <user>
+  - $(git branch 2> /dev/null)
 
 ```
 
-Valid completion additions are:
+- Anything between `<...>` will be added using the `compgen -A action` flag.
+- Anything else, will be appended to the `compgen -W` flag.
 
-| Keyword     | Meaning
-|-------------|---------------------
-| `alias`     | Alias names
-| `arrayvar`  | Array variable names
-| `binding`   | Readline key binding names
-| `builtin`   | Names of shell builtin commands
-| `command`   | Command names
-| `directory` | Directory names
-| `disabled`  | Names of disabled shell builtins
-| `enabled`   | Names of enabled shell builtins
-| `export`    | Names of exported shell variables
-| `file`      | File names
-| `function`  | Names of shell functions
-| `group`     | Group names
-| `helptopic` | Help topics as accepted by the help builtin
-| `hostname`  | Hostnames, as taken from the file specified by the HOSTFILE shell variable
-| `job`       | Job names
-| `keyword`   | Shell reserved words
-| `running`   | Names of running jobs
-| `service`   | Service names
-| `signal`    | Signal names
-| `stopped`   | Names of stopped jobs
-| `user`      | User names
-| `variable`  | Names of all shell variables
-
-Note that these are taken from the [Programmable Completion Builtin][compgen], 
-and will simply be added using the `compgen -A action` command.
+For more information about these custom completions, see the documentation for
+the [completely][completely] gem.
 
 
 ## Real World Examples

--- a/examples/completions/README.md
+++ b/examples/completions/README.md
@@ -26,7 +26,8 @@ commands:
 - name: download
   short: d
   help: Download a file
-  completions: [file]
+  completions:
+  - <file>
 
   args:
   - name: source
@@ -51,7 +52,9 @@ commands:
 - name: upload
   short: u
   help: Upload a file
-  completions: [directory, user]
+  completions:
+    - <directory>
+    - <user>
   args:
   - name: source
     required: true

--- a/examples/completions/src/bashly.yml
+++ b/examples/completions/src/bashly.yml
@@ -11,7 +11,8 @@ commands:
 - name: download
   short: d
   help: Download a file
-  completions: [file]
+  completions:
+  - <file>
 
   args:
   - name: source
@@ -36,7 +37,9 @@ commands:
 - name: upload
   short: u
   help: Upload a file
-  completions: [directory, user]
+  completions:
+    - <directory>
+    - <user>
   args:
   - name: source
     required: true

--- a/lib/bashly/concerns/completions.rb
+++ b/lib/bashly/concerns/completions.rb
@@ -31,18 +31,15 @@ module Bashly
       flags.map(&:name) + flags.map(&:short)
     end
 
-    def completion_actions
-      completions ? completions.map { |c| "<#{c}>" } : []
-    end
-
     def completion_words(with_version: false)
       trivial_flags = %w[--help -h]
       trivial_flags += %w[--version -v] if with_version
       all = (
         command_names + trivial_flags +
-        completion_flag_names + completion_actions
+        completion_flag_names
       )
 
+      all += completions if completions
       all.compact.uniq.sort
     end
 

--- a/spec/approvals/completions/advanced
+++ b/spec/approvals/completions/advanced
@@ -22,6 +22,7 @@ say goodbye:
 - "-h"
 - universe
 say goodbye universe:
+- "$(git branch)"
 - "--color"
 - "--help"
 - "--verbose"

--- a/spec/approvals/completions/script
+++ b/spec/approvals/completions/script
@@ -7,7 +7,7 @@ _say_completions() {
   local cur=${COMP_WORDS[COMP_CWORD]}
 
   case "$COMP_LINE" in
-    'say goodbye universe'*) COMPREPLY=($(compgen -W "--color --help --verbose -c -h -v" -- "$cur")) ;;
+    'say goodbye universe'*) COMPREPLY=($(compgen -W "$(git branch) --color --help --verbose -c -h -v" -- "$cur")) ;;
     'say hello world'*) COMPREPLY=($(compgen -A directory -A user -W "--force --help --verbose -h" -- "$cur")) ;;
     'say goodbye'*) COMPREPLY=($(compgen -W "--help -h universe" -- "$cur")) ;;
     'say hello'*) COMPREPLY=($(compgen -W "--help -h world" -- "$cur")) ;;

--- a/spec/bashly/models/command_spec.rb
+++ b/spec/bashly/models/command_spec.rb
@@ -93,7 +93,7 @@ describe Models::Command do
     end
   end
   
-  describe '#catch_all_help', :focus do
+  describe '#catch_all_help' do
     context "when catch_all is disabled" do
       it "returns nil" do
         expect(subject.catch_all_help).to be_nil

--- a/spec/fixtures/models/commands.yml
+++ b/spec/fixtures/models/commands.yml
@@ -130,7 +130,8 @@
 
 :completions_simple:
   name: get
-  completions: [file]
+  completions:
+  - <file>
 
   flags:
   - long: --force
@@ -142,13 +143,17 @@
   - name: hello
     commands:
     - name: world
-      completions: [directory, user]
+      completions:
+      - <directory>
+      - <user>
       flags:
       - long: --force
       - long: --verbose
   - name: goodbye
     commands:
     - name: universe
+      completions:
+      - $(git branch)
       flags:
       - long: --color
         short: -c


### PR DESCRIPTION
Instead of defining custom completions like this:

```yaml
completions:
- file
- user
```

It is now required to use the explicit syntax, as used by `completely`:

```yaml
completions:
- <file>
- <user>
```

This is done, so that we can easily use custom functions, for example, to show git branches:

```yaml
completions:
- <file>
- <user>
- $(git branch 2> /dev/null)
```

In addition - the majority of the bash completion documentation in the README was removed, so that we only have one canonical documentation in the completely gem.