### PR TITLE
Add default option for environment variables

### DIFF
--- a/Runfile
+++ b/Runfile
@@ -83,7 +83,13 @@ class Example
   end
 
   def test_commands
-    File.read("#{dir}/test.sh").scan(/\.\/#{config['name']}.*/)
+    filename = "#{dir}/test.sh"
+    result = File.read(filename)
+      .split(/\s*### Try Me ###\s*/).last
+      .split("\n")
+      .reject { |line| line.empty? or line.start_with? '#' }
+    abort "Can't find ### Try Me ### marker in #{filename}" if result.empty?
+    result
   end
 
   def test_output

--- a/examples/catch-all-advanced/test.sh
+++ b/examples/catch-all-advanced/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./cli
 ./cli download -h
 ./cli download source

--- a/examples/catch-all/test.sh
+++ b/examples/catch-all/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./download
 ./download -h
 ./download something

--- a/examples/colors/test.sh
+++ b/examples/colors/test.sh
@@ -4,4 +4,6 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./colorly

--- a/examples/command-default/test.sh
+++ b/examples/command-default/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./ftp
 ./ftp -h
 ./ftp download something

--- a/examples/command-groups/test.sh
+++ b/examples/command-groups/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./ftp
 ./ftp -h
 ./ftp login

--- a/examples/commands-nested/test.sh
+++ b/examples/commands-nested/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./cli
 ./cli -h
 ./cli dir

--- a/examples/commands/test.sh
+++ b/examples/commands/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./cli
 ./cli -h
 ./cli --version

--- a/examples/completions/test.sh
+++ b/examples/completions/test.sh
@@ -5,6 +5,8 @@ set -x
 bashly add comp function
 bashly generate
 
+### Try Me ###
+
 ./cli
 ./cli -h
 ./cli completions -h

--- a/examples/config-ini/test.sh
+++ b/examples/config-ini/test.sh
@@ -4,6 +4,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./configly -h
 ./configly set hello world
 ./configly set bashly works

--- a/examples/custom-includes/test.sh
+++ b/examples/custom-includes/test.sh
@@ -4,4 +4,6 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./download

--- a/examples/custom-strings/test.sh
+++ b/examples/custom-strings/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./download
 ./download -h
 ./download somesource

--- a/examples/default-values/test.sh
+++ b/examples/default-values/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./convert
 ./convert -h
 ./convert *.bmp

--- a/examples/dependencies/test.sh
+++ b/examples/dependencies/test.sh
@@ -4,5 +4,7 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./cli download
 ./cli upload

--- a/examples/docker-like/test.sh
+++ b/examples/docker-like/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./docker
 ./docker -h
 ./docker container

--- a/examples/environment-variables/README.md
+++ b/examples/environment-variables/README.md
@@ -11,10 +11,16 @@ name: cli
 help: Sample application that requires environment variables
 version: 0.1.0
 
-# This option adds usage text to the help message in the generated script.
+# These two variable options add usage text to the help message in the
+# generated script.
+# In addition, the value of the variable `ENVIRONMENT` will be set to
+# `development` if it is not already set by the user.
 environment_variables:
 - name: api_key
   help: Set your API key
+- name: environment
+  help: One of development, production or test
+  default: development
 
 commands:
 - name: verify
@@ -73,6 +79,9 @@ Environment Variables:
   API_KEY
     Set your API key
 
+  ENVIRONMENT
+    One of development, production or test
+
 
 
 ```
@@ -96,6 +105,14 @@ Environment Variables:
   MY_SECRET (required)
     Your secret
 
+
+
+```
+
+### `$ ./cli verify`
+
+```shell
+missing required environment variable: MY_SECRET
 
 
 ```

--- a/examples/environment-variables/README.md
+++ b/examples/environment-variables/README.md
@@ -81,6 +81,7 @@ Environment Variables:
 
   ENVIRONMENT
     One of development, production or test
+    Default: development
 
 
 
@@ -117,15 +118,22 @@ missing required environment variable: MY_SECRET
 
 ```
 
-### `$ ./cli verify`
+### `$ MY_SECRET="there is no spoon" ./cli verify`
 
 ```shell
-missing required environment variable: MY_SECRET
+# this file is located in 'src/verify_command.sh'
+# code for 'cli verify' goes here
+# you can edit it freely and regenerate (it will not be overwritten)
+args: none
+environment:
+- API_KEY=
+- ENVIRONMENT=development
+- MY_SECRET=there is no spoon
 
 
 ```
 
-### `$ ./cli verify`
+### `$ ENVIRONMENT=production ./cli verify`
 
 ```shell
 missing required environment variable: MY_SECRET

--- a/examples/environment-variables/README.md
+++ b/examples/environment-variables/README.md
@@ -11,16 +11,10 @@ name: cli
 help: Sample application that requires environment variables
 version: 0.1.0
 
-# These two variable options add usage text to the help message in the
-# generated script.
-# In addition, the value of the variable `ENVIRONMENT` will be set to
-# `development` if it is not already set by the user.
+# This option adds usage text to the help message in the generated script.
 environment_variables:
 - name: api_key
   help: Set your API key
-- name: environment
-  help: One of development, production or test
-  default: development
 
 commands:
 - name: verify
@@ -28,12 +22,19 @@ commands:
   help: Verify your user
 
   # This option belongs to the `verify` command and will appear in its help
-  # message. In addition, setting `required: true` will halt the script's 
-  # execution with a friendly error message, unless the variable is set.
+  # message.
   environment_variables:
+  # Setting `required: true` will halt the script's execution with a
+  # friendly error message, unless the variable is set.
   - name: my_secret
     help: Your secret
     required: true
+  
+  # Using the `default: value` option will cause the value to variable to be 
+  # set if it is not provided by the user.
+  - name: environment
+    help: One of development, production or test
+    default: development
 ```
 
 ## Generated script output
@@ -79,10 +80,6 @@ Environment Variables:
   API_KEY
     Set your API key
 
-  ENVIRONMENT
-    One of development, production or test
-    Default: development
-
 
 
 ```
@@ -105,6 +102,10 @@ Options:
 Environment Variables:
   MY_SECRET (required)
     Your secret
+
+  ENVIRONMENT
+    One of development, production or test
+    Default: development
 
 
 
@@ -133,10 +134,17 @@ environment:
 
 ```
 
-### `$ ENVIRONMENT=production ./cli verify`
+### `$ ENVIRONMENT=production MY_SECRET=safe-with-me ./cli verify`
 
 ```shell
-missing required environment variable: MY_SECRET
+# this file is located in 'src/verify_command.sh'
+# code for 'cli verify' goes here
+# you can edit it freely and regenerate (it will not be overwritten)
+args: none
+environment:
+- API_KEY=
+- ENVIRONMENT=production
+- MY_SECRET=safe-with-me
 
 
 ```

--- a/examples/environment-variables/cli
+++ b/examples/environment-variables/cli
@@ -44,12 +44,6 @@ cli_usage() {
     echo "  API_KEY"
     printf "    Set your API key\n"
     echo
-    
-    # :environment_variable.usage
-    echo "  ENVIRONMENT"
-    printf "    One of development, production or test\n"
-    printf "    Default: development\n"
-    echo
 
   fi
 }
@@ -85,6 +79,12 @@ cli_verify_usage() {
     # :environment_variable.usage
     echo "  MY_SECRET (required)"
     printf "    Your secret\n"
+    echo
+    
+    # :environment_variable.usage
+    echo "  ENVIRONMENT"
+    printf "    One of development, production or test\n"
+    printf "    Default: development\n"
     echo
 
   fi
@@ -142,7 +142,6 @@ parse_requirements() {
   
   esac
   # :command.environment_variables_filter
-  export ENVIRONMENT="${ENVIRONMENT:-development}"
   # :command.dependencies_filter
   # :command.command_filter
   action=$1
@@ -206,6 +205,7 @@ cli_verify_parse_requirements() {
   
   esac
   # :command.environment_variables_filter
+  export ENVIRONMENT="${ENVIRONMENT:-development}"
   if [[ -z "$MY_SECRET" ]]; then
     printf "missing required environment variable: MY_SECRET\n"
     exit 1

--- a/examples/environment-variables/cli
+++ b/examples/environment-variables/cli
@@ -44,6 +44,11 @@ cli_usage() {
     echo "  API_KEY"
     printf "    Set your API key\n"
     echo
+    
+    # :environment_variable.usage
+    echo "  ENVIRONMENT"
+    printf "    One of development, production or test\n"
+    echo
 
   fi
 }
@@ -114,6 +119,8 @@ cli_verify_command() {
   inspect_args
   
   echo "environment:"
+  echo "- API_KEY=$API_KEY"
+  echo "- ENVIRONMENT=$ENVIRONMENT"
   echo "- MY_SECRET=$MY_SECRET"
 }
 

--- a/examples/environment-variables/cli
+++ b/examples/environment-variables/cli
@@ -48,6 +48,7 @@ cli_usage() {
     # :environment_variable.usage
     echo "  ENVIRONMENT"
     printf "    One of development, production or test\n"
+    printf "    Default: development\n"
     echo
 
   fi
@@ -141,6 +142,7 @@ parse_requirements() {
   
   esac
   # :command.environment_variables_filter
+  export ENVIRONMENT="${ENVIRONMENT:-development}"
   # :command.dependencies_filter
   # :command.command_filter
   action=$1

--- a/examples/environment-variables/src/bashly.yml
+++ b/examples/environment-variables/src/bashly.yml
@@ -2,16 +2,10 @@ name: cli
 help: Sample application that requires environment variables
 version: 0.1.0
 
-# These two variable options add usage text to the help message in the
-# generated script.
-# In addition, the value of the variable `ENVIRONMENT` will be set to
-# `development` if it is not already set by the user.
+# This option adds usage text to the help message in the generated script.
 environment_variables:
 - name: api_key
   help: Set your API key
-- name: environment
-  help: One of development, production or test
-  default: development
 
 commands:
 - name: verify
@@ -19,9 +13,16 @@ commands:
   help: Verify your user
 
   # This option belongs to the `verify` command and will appear in its help
-  # message. In addition, setting `required: true` will halt the script's 
-  # execution with a friendly error message, unless the variable is set.
+  # message.
   environment_variables:
+  # Setting `required: true` will halt the script's execution with a
+  # friendly error message, unless the variable is set.
   - name: my_secret
     help: Your secret
     required: true
+  
+  # Using the `default: value` option will cause the value to variable to be 
+  # set if it is not provided by the user.
+  - name: environment
+    help: One of development, production or test
+    default: development

--- a/examples/environment-variables/src/bashly.yml
+++ b/examples/environment-variables/src/bashly.yml
@@ -2,10 +2,16 @@ name: cli
 help: Sample application that requires environment variables
 version: 0.1.0
 
-# This option adds usage text to the help message in the generated script.
+# These two variable options add usage text to the help message in the
+# generated script.
+# In addition, the value of the variable `ENVIRONMENT` will be set to
+# `development` if it is not already set by the user.
 environment_variables:
 - name: api_key
   help: Set your API key
+- name: environment
+  help: One of development, production or test
+  default: development
 
 commands:
 - name: verify

--- a/examples/environment-variables/src/verify_command.sh
+++ b/examples/environment-variables/src/verify_command.sh
@@ -4,4 +4,6 @@ echo "# you can edit it freely and regenerate (it will not be overwritten)"
 inspect_args
 
 echo "environment:"
+echo "- API_KEY=$API_KEY"
+echo "- ENVIRONMENT=$ENVIRONMENT"
 echo "- MY_SECRET=$MY_SECRET"

--- a/examples/environment-variables/test.sh
+++ b/examples/environment-variables/test.sh
@@ -9,3 +9,4 @@ bashly generate
 ./cli verify -h
 ./cli verify
 MY_SECRET="there is no spoon" ./cli verify
+ENVIRONMENT=production ./cli verify

--- a/examples/environment-variables/test.sh
+++ b/examples/environment-variables/test.sh
@@ -11,4 +11,4 @@ bashly generate
 ./cli verify -h
 ./cli verify
 MY_SECRET="there is no spoon" ./cli verify
-ENVIRONMENT=production ./cli verify
+ENVIRONMENT=production MY_SECRET=safe-with-me ./cli verify

--- a/examples/environment-variables/test.sh
+++ b/examples/environment-variables/test.sh
@@ -4,6 +4,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./cli
 ./cli -h
 ./cli verify -h

--- a/examples/extensible-delegate/test.sh
+++ b/examples/extensible-delegate/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./mygit
 ./mygit push
 

--- a/examples/extensible/test.sh
+++ b/examples/extensible/test.sh
@@ -9,5 +9,7 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./cli
 ./cli status --some --flags

--- a/examples/footer/test.sh
+++ b/examples/footer/test.sh
@@ -6,5 +6,7 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./download
 ./download -h

--- a/examples/git-like/test.sh
+++ b/examples/git-like/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./git
 ./git -h
 ./git s

--- a/examples/minimal/test.sh
+++ b/examples/minimal/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./download
 ./download -h
 ./download -v

--- a/examples/minus-v/test.sh
+++ b/examples/minus-v/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./cli
 ./cli --help
 ./cli --version

--- a/examples/multiline/test.sh
+++ b/examples/multiline/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./multi
 ./multi -h
 ./multi multiline

--- a/examples/whitelist/test.sh
+++ b/examples/whitelist/test.sh
@@ -6,6 +6,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./login
 ./login -h
 ./login america

--- a/examples/yaml/test.sh
+++ b/examples/yaml/test.sh
@@ -4,6 +4,8 @@ set -x
 
 bashly generate
 
+### Try Me ###
+
 ./yaml -h
 ./yaml settings.yml
 ./yaml settings.yml --prefix config_

--- a/lib/bashly/models/command.rb
+++ b/lib/bashly/models/command.rb
@@ -92,6 +92,11 @@ module Bashly
         commands.find { |c| c.default }
       end
 
+      # Returns an array of all the default Environment Variables
+      def default_environment_variables
+        environment_variables.select &:default
+      end
+
       # Returns an array of all the default Flags
       def default_flags
         flags.select &:default

--- a/lib/bashly/views/command/environment_variables_filter.erb
+++ b/lib/bashly/views/command/environment_variables_filter.erb
@@ -1,4 +1,9 @@
 # :command.environment_variables_filter
+<%- if default_environment_variables.any? -%>
+<%- default_environment_variables.each do |env_var| -%>
+export <%= env_var.name.upcase %>="${<%= env_var.name.upcase %>:-<%= env_var.default %>}"
+<%- end -%>
+<%- end -%>
 <%- if required_environment_variables.any? -%>
 <%- required_environment_variables.each do |env_var| -%>
 if [[ -z "$<%= env_var.name.upcase %>" ]]; then

--- a/lib/bashly/views/environment_variable/usage.erb
+++ b/lib/bashly/views/environment_variable/usage.erb
@@ -1,4 +1,7 @@
 # :environment_variable.usage
 echo "  <%= usage_string extended: true %>"
 printf "<%= help.wrap(76).indent(4).sanitize_for_print %>\n"
+<%- if default -%>
+printf "    <%= strings[:default] % { value: default } -%>\n"
+<%- end -%>
 echo

--- a/spec/approvals/examples/environment-variables
+++ b/spec/approvals/examples/environment-variables
@@ -37,10 +37,6 @@ Environment Variables:
   API_KEY
     Set your API key
 
-  ENVIRONMENT
-    One of development, production or test
-    Default: development
-
 + ./cli verify -h
 cli verify - Verify your user
 
@@ -58,6 +54,10 @@ Environment Variables:
   MY_SECRET (required)
     Your secret
 
+  ENVIRONMENT
+    One of development, production or test
+    Default: development
+
 + ./cli verify
 missing required environment variable: MY_SECRET
 + MY_SECRET='there is no spoon'
@@ -71,5 +71,13 @@ environment:
 - ENVIRONMENT=development
 - MY_SECRET=there is no spoon
 + ENVIRONMENT=production
++ MY_SECRET=safe-with-me
 + ./cli verify
-missing required environment variable: MY_SECRET
+# this file is located in 'src/verify_command.sh'
+# code for 'cli verify' goes here
+# you can edit it freely and regenerate (it will not be overwritten)
+args: none
+environment:
+- API_KEY=
+- ENVIRONMENT=production
+- MY_SECRET=safe-with-me

--- a/spec/approvals/examples/environment-variables
+++ b/spec/approvals/examples/environment-variables
@@ -37,6 +37,10 @@ Environment Variables:
   API_KEY
     Set your API key
 
+  ENVIRONMENT
+    One of development, production or test
+    Default: development
+
 + ./cli verify -h
 cli verify - Verify your user
 
@@ -63,4 +67,9 @@ missing required environment variable: MY_SECRET
 # you can edit it freely and regenerate (it will not be overwritten)
 args: none
 environment:
+- API_KEY=
+- ENVIRONMENT=development
 - MY_SECRET=there is no spoon
++ ENVIRONMENT=production
++ ./cli verify
+missing required environment variable: MY_SECRET


### PR DESCRIPTION
This PR adds a `default: value` option to `environment_variables` elements to make it consistent with `args` and `flags`.

In addition, the example README generator was updated to better extract the example commands from the `**/test.sh` files.