### PR TITLE
Sort lib files to ensure consistent inclusion

### DIFF
--- a/lib/bashly/models/command.rb
+++ b/lib/bashly/models/command.rb
@@ -209,7 +209,7 @@ module Bashly
       # This is meant to provide the user with the ability to add custom
       # functions
       def user_lib
-        @user_lib ||= Dir["#{Settings.source_dir}/lib/**/*.sh"]
+        @user_lib ||= Dir["#{Settings.source_dir}/lib/**/*.sh"].sort
       end
 
       # Raise an exception if there are some serious issues with the command


### PR DESCRIPTION
I'n looking to commit the generated output from bashly into my source repository so that I can easily fetch it within other scripts. The generated bashly script has some other dependencies in my repository, so whilst I'd like to push it somewhere to publish, this doesn't work all that cleanly.

So that I can make sure that the file is always updated, I've added a test run by my CI server that confirms the committed version matches a freshly built one - this will cause my CI to fail if I've forgotten to commit an update. However, I'm seeing CI failures because my local MacOS machine is ordering the content imported from `lib/` differently to how my CircleCI instance is.

This PR just adds a `sort` onto the files found in the `lib/` directory to ensure consistent ordering.