### PR TITLE
Fix generate spec to actually test for overwriting

### DIFF
--- a/spec/bashly/commands/generate_spec.rb
+++ b/spec/bashly/commands/generate_spec.rb
@@ -28,12 +28,12 @@ describe Commands::Generate do
     context "when source files already exist" do
       before do
         expect { subject.run %w[generate] }.to output_approval('cli/generate/no-args')
-        File.write "#{source_dir}/cli_get_command.sh", "some new user content"
+        File.write "#{source_dir}/download_command.sh", "some new user content"
       end
 
       it "does not overwrite them" do
         expect { subject.run %w[generate] }.to output_approval('cli/generate/no-args-skip')
-        expect(File.read "#{source_dir}/cli_get_command.sh").to eq "some new user content"
+        expect(File.read "#{source_dir}/download_command.sh").to eq "some new user content"
       end
     end
 


### PR DESCRIPTION
The bashly.yml that the spec uses does not define a "cli-get" command, so if the generator *were* overwriting this file the spec would not catch it. Change the spec to use a command name that the example yml does have, so that it would be overwritten if this happens.