### PR TITLE
Fix and merge #109, #110 and #111

### DIFF
--- a/Runfile
+++ b/Runfile
@@ -1,7 +1,9 @@
 require "runfile-tasks"
 require "byebug"
+require "colsole"
 require_relative 'lib/bashly'
 require_relative 'helpers/example'
+include Colsole
 
 title   "Bashly Developer Toolbelt"
 summary "Runfile tasks for building the Bashly gem"

--- a/lib/bashly/commands/generate.rb
+++ b/lib/bashly/commands/generate.rb
@@ -3,11 +3,12 @@ module Bashly
     class Generate < Base
       help "Generate the bash script and required files"
 
-      usage "bashly generate [--force --wrap FUNCTION]"
+      usage "bashly generate [--force --quiet --wrap FUNCTION]"
       usage "bashly generate (-h|--help)"
 
       option "-f --force", "Overwrite existing files"
       option "-w --wrap FUNCTION", "Wrap the entire script in a function so it can also be sourced"
+      option "-q --quiet", "Less verbose output"
 
       environment "BASHLY_SOURCE_DIR", "The path containing the bashly configuration and source files [default: src]"
       environment "BASHLY_TARGET_DIR", "The path to use for creating the bash script [default: .]"
@@ -18,13 +19,13 @@ module Bashly
       def run
         create_user_files
         create_master_script
-        say "run !txtpur!#{master_script_path} --help!txtrst! to test your bash script"
+        say "run !txtpur!#{master_script_path} --help!txtrst! to test your bash script" unless args['--quiet']
       end
 
     private
 
       def create_user_files
-        say "creating user files in !txtgrn!#{Settings.source_dir}"
+        say "creating user files in !txtgrn!#{Settings.source_dir}" unless args['--quiet']
 
         create_file "#{Settings.source_dir}/initialize.sh", command.render(:default_initialize_script)
 
@@ -50,7 +51,7 @@ module Bashly
 
       def create_file(file, content)
         if File.exist? file and !args['--force']
-          say "skipped !txtgrn!#{file}!txtrst! (exists)"
+          say "skipped !txtgrn!#{file}!txtrst! (exists)" unless args['--quiet']
         else
           File.write file, content
           say "created !txtgrn!#{file}"
@@ -60,7 +61,7 @@ module Bashly
       def create_master_script
         File.write master_script_path, script.code
         FileUtils.chmod "+x", master_script_path
-        say "created !txtgrn!#{master_script_path}"
+        say "created !txtgrn!#{master_script_path}" unless args['--quiet']
       end
 
       def script

--- a/lib/bashly/commands/generate.rb
+++ b/lib/bashly/commands/generate.rb
@@ -8,7 +8,7 @@ module Bashly
 
       option "-f --force", "Overwrite existing files"
       option "-w --wrap FUNCTION", "Wrap the entire script in a function so it can also be sourced"
-      option "-q --quiet", "Less verbose output"
+      option "-q --quiet", "Disable on-screen progress report"
 
       environment "BASHLY_SOURCE_DIR", "The path containing the bashly configuration and source files [default: src]"
       environment "BASHLY_TARGET_DIR", "The path to use for creating the bash script [default: .]"
@@ -19,13 +19,17 @@ module Bashly
       def run
         create_user_files
         create_master_script
-        say "run !txtpur!#{master_script_path} --help!txtrst! to test your bash script" unless args['--quiet']
+        quiet_say "run !txtpur!#{master_script_path} --help!txtrst! to test your bash script"
       end
 
     private
 
+      def quiet_say(message)
+        say message unless args['--quiet']
+      end
+
       def create_user_files
-        say "creating user files in !txtgrn!#{Settings.source_dir}" unless args['--quiet']
+        quiet_say "creating user files in !txtgrn!#{Settings.source_dir}"
 
         create_file "#{Settings.source_dir}/initialize.sh", command.render(:default_initialize_script)
 
@@ -51,17 +55,17 @@ module Bashly
 
       def create_file(file, content)
         if File.exist? file and !args['--force']
-          say "skipped !txtgrn!#{file}!txtrst! (exists)" unless args['--quiet']
+          quiet_say "skipped !txtgrn!#{file}!txtrst! (exists)"
         else
           File.write file, content
-          say "created !txtgrn!#{file}"
+          quiet_say "created !txtgrn!#{file}"
         end
       end
 
       def create_master_script
         File.write master_script_path, script.code
         FileUtils.chmod "+x", master_script_path
-        say "created !txtgrn!#{master_script_path}" unless args['--quiet']
+        quiet_say "created !txtgrn!#{master_script_path}"
       end
 
       def script

--- a/spec/approvals/cli/generate/help
+++ b/spec/approvals/cli/generate/help
@@ -12,7 +12,7 @@ Options:
     Wrap the entire script in a function so it can also be sourced
 
   -q --quiet
-    Less verbose output
+    Disable on-screen progress report
 
   -h --help
     Show this help

--- a/spec/approvals/cli/generate/help
+++ b/spec/approvals/cli/generate/help
@@ -1,7 +1,7 @@
 Generate the bash script and required files
 
 Usage:
-  bashly generate [--force --wrap FUNCTION]
+  bashly generate [--force --quiet --wrap FUNCTION]
   bashly generate (-h|--help)
 
 Options:
@@ -10,6 +10,9 @@ Options:
 
   -w --wrap FUNCTION
     Wrap the entire script in a function so it can also be sourced
+
+  -q --quiet
+    Less verbose output
 
   -h --help
     Show this help

--- a/spec/approvals/cli/generate/quiet
+++ b/spec/approvals/cli/generate/quiet
@@ -1,3 +1,0 @@
-created spec/tmp/src/initialize.sh
-created spec/tmp/src/download_command.sh
-created spec/tmp/src/upload_command.sh

--- a/spec/approvals/cli/generate/quiet
+++ b/spec/approvals/cli/generate/quiet
@@ -1,0 +1,3 @@
+created spec/tmp/src/initialize.sh
+created spec/tmp/src/download_command.sh
+created spec/tmp/src/upload_command.sh

--- a/spec/bashly/commands/generate_spec.rb
+++ b/spec/bashly/commands/generate_spec.rb
@@ -51,6 +51,34 @@ describe Commands::Generate do
     end
   end
 
+  context "with --quiet" do
+    let(:cli_script) { "#{target_dir}/cli" }
+
+    before do
+      reset_tmp_dir
+      success = system "mkdir -p #{source_dir} && cp lib/bashly/templates/bashly.yml #{source_dir}/bashly.yml"
+      expect(success).to be true
+    end
+
+    it "generates the cli script" do
+      expect { subject.run %w[generate --quiet] }.to output_approval('cli/generate/quiet')
+      expect(File).to exist(cli_script)
+    end
+
+    context "when source files already exist" do
+      before do
+        expect { subject.run %w[generate --quiet] } #.to output_nothing
+        File.write "#{source_dir}/download_command.sh", "some new user content"
+      end
+
+      it "does not overwrite them" do
+        expect { subject.run %w[generate --quiet] } #.to output_nothing
+        expect(File.read "#{source_dir}/download_command.sh").to eq "some new user content"
+      end
+    end
+
+  end
+
   context "with --wrap function" do
     let(:cli_script) { "#{target_dir}/cli" }
 

--- a/spec/bashly/commands/generate_spec.rb
+++ b/spec/bashly/commands/generate_spec.rb
@@ -61,22 +61,9 @@ describe Commands::Generate do
     end
 
     it "generates the cli script" do
-      expect { subject.run %w[generate --quiet] }.to output_approval('cli/generate/quiet')
+      expect { subject.run %w[generate --quiet] }.to_not output.to_stdout
       expect(File).to exist(cli_script)
     end
-
-    context "when source files already exist" do
-      before do
-        expect { subject.run %w[generate --quiet] } #.to output_nothing
-        File.write "#{source_dir}/download_command.sh", "some new user content"
-      end
-
-      it "does not overwrite them" do
-        expect { subject.run %w[generate --quiet] } #.to output_nothing
-        expect(File.read "#{source_dir}/download_command.sh").to eq "some new user content"
-      end
-    end
-
   end
 
   context "with --wrap function" do


### PR DESCRIPTION
- Require and include `Colsole` since the latest [Runfile 0.12.0](https://github.com/DannyBen/runfile/releases/tag/v0.12.0) no longer brings it - closes #111 
- Refactor `say <something> unless args['--quiet']` to `quiet_say <something>`
- Make the `bashly generate --quiet` output completely quiet (even created files).
- Closes #109 - merged in
- Closes #110 - merged in
- Adjust specs accordingly

