### PR TITLE
CHG: Permit flags as both prequel or sequel of positional arguments

### DIFF
--- a/lib/bashly/models/command.rb
+++ b/lib/bashly/models/command.rb
@@ -197,10 +197,13 @@ module Bashly
       def usage_string
         result = [full_name]
         result << "[command]" if commands.any?
+        result << "[options]" unless flags.empty?
+        required_flags.each do |flag|
+          result << flag.usage_string
+        end
         args.each do |arg|
           result << arg.usage_string
         end
-        result << "[options]" unless flags.empty?
         result << catch_all_usage if catch_all
         result.join " "
       end

--- a/lib/bashly/views/command/parse_requirements.erb
+++ b/lib/bashly/views/command/parse_requirements.erb
@@ -8,9 +8,9 @@ parse_requirements() {
 <%= render(:environment_variables_filter).indent 2 %>
 <%= render(:dependencies_filter).indent 2 %>
 <%= render(:command_filter).indent 2 %>
-<%= render(:required_args_filter).indent 2 %>
 <%= render(:required_flags_filter).indent 2 %>
 <%= render(:parse_requirements_while).indent 2 %>
+<%= render(:required_args_filter).indent 2 %>
 <%= render(:catch_all_filter).indent 2 %>
 <%= render(:default_assignments).indent 2 %>
 <%= render(:whitelist_filter).indent 2 %>

--- a/lib/bashly/views/command/required_args_filter.erb
+++ b/lib/bashly/views/command/required_args_filter.erb
@@ -1,11 +1,9 @@
 # :command.required_args_filter
 % required_args.each do |arg|
-if [[ $1 && $1 != -* ]]; then
-  args[<%= arg.name %>]=$1
-  shift
-else
+if [[  ! ${args[<%= arg.name %>]} ]];then 
   printf "<%= strings[:missing_required_argument] % { arg: arg.name.upcase, usage: usage_string } %>\n"
-  exit 1
+  
+  exec $0 $action -h
 fi
 
 % end


### PR DESCRIPTION
This make flags:
- usable either before, after, or both sides of positional arguments
- breaking if one appears in between two positional arguments
- repeatable as they'll just overide themself, so there is no problem having same flag used in both  sides of positionals.
- '[options]' in usage a prequel of positional in help message (more often seen in th wild, more natural to some, arguable to many)


Also, this PR change behavior of missing positional argument by exec'ing self plus -h after original error
<sub>(_This is because it was found really frustrating for discovery that a subcommand with positional argument would be discoverable by iterating over errors or forcing a -h,
a-contrario of nearly all other case that bashly generates._)</sub>

### Note :
- these changes are known to be quite opiniated.
- The very high robustness and coherence that bashly shows in behavior and code probably makes this PR unable to qualify for further treatment
More than enough to not take any offense in case this PR is thrown away without any other care.
(Deep thanks for your very valuable,trustable and elegant work.)