### PR TITLE
Make generated scripts compatible with bash strict mode

### DIFF
--- a/examples/catch-all-advanced/src/initialize.sh
+++ b/examples/catch-all-advanced/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/catch-all/src/initialize.sh
+++ b/examples/catch-all/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/command-default/src/initialize.sh
+++ b/examples/command-default/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/command-groups/src/initialize.sh
+++ b/examples/command-groups/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/commands-nested/src/initialize.sh
+++ b/examples/commands-nested/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/commands/src/initialize.sh
+++ b/examples/commands/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/config-ini/src/lib/config.sh
+++ b/examples/config-ini/src/lib/config.sh
@@ -22,6 +22,7 @@ config_init() {
 config_get() {
   key=$1
   regex="^$key\s*=\s*(.+)$"
+  value=''
 
   config_init
   
@@ -122,5 +123,5 @@ config_keys() {
 #   fi
 #
 config_has_key() {
-  [[ $(config_get "$1") ]]
+  [[ $(config_get "${1:-}") ]]
 }

--- a/examples/custom-strings/src/initialize.sh
+++ b/examples/custom-strings/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/default-values/src/initialize.sh
+++ b/examples/default-values/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/docker-like/src/initialize.sh
+++ b/examples/docker-like/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/environment-variables/src/verify_command.sh
+++ b/examples/environment-variables/src/verify_command.sh
@@ -4,6 +4,6 @@ echo "# you can edit it freely and regenerate (it will not be overwritten)"
 inspect_args
 
 echo "environment:"
-echo "- API_KEY=$API_KEY"
-echo "- ENVIRONMENT=$ENVIRONMENT"
-echo "- MY_SECRET=$MY_SECRET"
+echo "- API_KEY=${API_KEY:-}"
+echo "- ENVIRONMENT=${ENVIRONMENT:-}"
+echo "- MY_SECRET=${MY_SECRET:-}"

--- a/examples/extensible-delegate/src/initialize.sh
+++ b/examples/extensible-delegate/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/extensible/src/initialize.sh
+++ b/examples/extensible/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/footer/src/initialize.sh
+++ b/examples/footer/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/git-like/src/initialize.sh
+++ b/examples/git-like/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/minimal/src/initialize.sh
+++ b/examples/minimal/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/minus-v/src/initialize.sh
+++ b/examples/minus-v/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/multiline/src/initialize.sh
+++ b/examples/multiline/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/validations/src/initialize.sh
+++ b/examples/validations/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/whitelist/src/initialize.sh
+++ b/examples/whitelist/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/yaml/src/root_command.sh
+++ b/examples/yaml/src/root_command.sh
@@ -1,6 +1,6 @@
-filename=${args[filename]}
-variable=${args[variable]}
-prefix=${args[--prefix]}
+filename=${args[filename]:-}
+variable=${args[variable]:-}
+prefix=${args[--prefix]:-}
 
 if [[ $variable ]]; then
   eval "$(yaml_load "$filename" "$prefix")"

--- a/lib/bashly/commands/generate.rb
+++ b/lib/bashly/commands/generate.rb
@@ -13,6 +13,7 @@ module Bashly
 
       environment "BASHLY_SOURCE_DIR", "The path containing the bashly configuration and source files [default: src]"
       environment "BASHLY_TARGET_DIR", "The path to use for creating the bash script [default: .]"
+      environment "BASHLY_STRICT", "When not empty, enable bash strict mode (set -euo pipefail)"
 
       example "bashly generate --force"
       example "bashly generate --wrap my_function"

--- a/lib/bashly/views/command/catch_all_filter.erb
+++ b/lib/bashly/views/command/catch_all_filter.erb
@@ -1,6 +1,6 @@
 # :command.catch_all_filter
 % if catch_all_required?
-if [[ ! -v other_args[@] ]]; then
+if [[ ${#other_args[@]} -eq 0 ]]; then
   printf "<%= strings[:missing_required_argument] % { arg: catch_all_label, usage: usage_string } %>\n"
   exit 1
 fi

--- a/lib/bashly/views/command/catch_all_filter.erb
+++ b/lib/bashly/views/command/catch_all_filter.erb
@@ -1,6 +1,6 @@
 # :command.catch_all_filter
 % if catch_all_required?
-if [[ ${#other_args[@]} -eq 0 ]]; then
+if [[ ! -v other_args[@] ]]; then
   printf "<%= strings[:missing_required_argument] % { arg: catch_all_label, usage: usage_string } %>\n"
   exit 1
 fi

--- a/lib/bashly/views/command/command_filter.erb
+++ b/lib/bashly/views/command/command_filter.erb
@@ -1,6 +1,6 @@
 # :command.command_filter
 % if commands.any?
-action=$1
+action=${1:-}
 
 case $action in
 -* )

--- a/lib/bashly/views/command/default_assignments.erb
+++ b/lib/bashly/views/command/default_assignments.erb
@@ -1,7 +1,7 @@
 # :command.default_assignments
 % default_args.each do |arg|
-[[ -n ${args[<%= arg.name %>]} ]] || args[<%= arg.name %>]="<%= arg.default %>"
+[[ -n ${args[<%= arg.name %>]:-} ]] || args[<%= arg.name %>]="<%= arg.default %>"
 % end
 % default_flags.each do |flag|
-[[ -n ${args[<%= flag.long %>]} ]] || args[<%= flag.long %>]="<%= flag.default %>"
+[[ -n ${args[<%= flag.long %>]:-} ]] || args[<%= flag.long %>]="<%= flag.default %>"
 % end

--- a/lib/bashly/views/command/default_initialize_script.erb
+++ b/lib/bashly/views/command/default_initialize_script.erb
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment vairables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment vairables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/lib/bashly/views/command/environment_variables_filter.erb
+++ b/lib/bashly/views/command/environment_variables_filter.erb
@@ -6,7 +6,7 @@ export <%= env_var.name.upcase %>="${<%= env_var.name.upcase %>:-<%= env_var.def
 % end
 % if required_environment_variables.any?
 % required_environment_variables.each do |env_var|
-if [[ -z "$<%= env_var.name.upcase %>" ]]; then
+if [[ -z "${<%= env_var.name.upcase %>:-}" ]]; then
   printf "<%= strings[:missing_required_environment_variable] % { var: env_var.name.upcase } %>\n"
   exit 1
 fi

--- a/lib/bashly/views/command/fixed_flags_filter.erb
+++ b/lib/bashly/views/command/fixed_flags_filter.erb
@@ -1,5 +1,5 @@
 # :command.fixed_flag_filter
-case "$1" in
+case "${1:-}" in
 % if short_flag_exist? "-v"
 --version )
 % else

--- a/lib/bashly/views/command/initialize.erb
+++ b/lib/bashly/views/command/initialize.erb
@@ -2,7 +2,7 @@
 initialize() {
   version="<%= version %>"
   long_usage=''
-  set -e
+  <%= ENV['BASHLY_STRICT'] ? "set -euo pipefail" : "set -e" %>
 
 <%= load_user_file("initialize.sh", placeholder: false).indent 2 %>
 }

--- a/lib/bashly/views/command/inspect_args.erb
+++ b/lib/bashly/views/command/inspect_args.erb
@@ -1,14 +1,14 @@
 # :command.inspect_args
 inspect_args() {
   readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
-  if (( ${#args[@]} )); then
+  if [[ -v args[@] ]]; then
     echo args:
     for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
   else
     echo args: none
   fi
 
-  if (( ${#other_args[@]} )); then
+  if [[ -v other_args[@] ]]; then
     echo
     echo other_args:
     echo "- \${other_args[*]} = ${other_args[*]}"

--- a/lib/bashly/views/command/inspect_args.erb
+++ b/lib/bashly/views/command/inspect_args.erb
@@ -1,14 +1,14 @@
 # :command.inspect_args
 inspect_args() {
   readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
-  if [[ -v args[@] ]]; then
+  if (( ${#args[@]} )); then
     echo args:
     for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
   else
     echo args: none
   fi
 
-  if [[ -v other_args[@] ]]; then
+  if (( ${#other_args[@]} )); then
     echo
     echo other_args:
     echo "- \${other_args[*]} = ${other_args[*]}"

--- a/lib/bashly/views/command/run.erb
+++ b/lib/bashly/views/command/run.erb
@@ -9,7 +9,7 @@ run() {
   <%- condition = "if" -%>
   <%- deep_commands.each do |command| -%>
   <%= condition %> [[ $action == "<%= command.action_name %>" ]]; then
-    if [[ ${args[--help]} ]]; then
+    if [[ -v args[--help] ]]; then
       long_usage=yes
       <%= command.function_name %>_usage
     else

--- a/lib/bashly/views/command/run.erb
+++ b/lib/bashly/views/command/run.erb
@@ -1,15 +1,15 @@
 # :command.run
 run() {
-  declare -A args
-  declare -a other_args
-  declare -a input
+  declare -A args=()
+  declare -a other_args=()
+  declare -a input=()
   normalize_input "$@"
   parse_requirements "${input[@]}"
 
   <%- condition = "if" -%>
   <%- deep_commands.each do |command| -%>
   <%= condition %> [[ $action == "<%= command.action_name %>" ]]; then
-    if [[ -v args[--help] ]]; then
+    if [[ ${args[--help]:-} ]]; then
       long_usage=yes
       <%= command.function_name %>_usage
     else

--- a/spec/approvals/cli/generate/help
+++ b/spec/approvals/cli/generate/help
@@ -27,6 +27,9 @@ Environment Variables:
   BASHLY_TARGET_DIR
     The path to use for creating the bash script [default: .]
 
+  BASHLY_STRICT
+    When not empty, enable bash strict mode (set -euo pipefail)
+
 Examples:
   bashly generate --force
   bashly generate --wrap my_function

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,9 @@ ENV['TTY'] = 'off'
 ENV['COLUMNS'] = '80'
 ENV['LINES'] = '30'
 
+# Force generated scripts to strict mode (set -euo pipefile)
+ENV['BASHLY_STRICT'] = '1'
+
 RSpec.configure do |c|
   c.include SpecMixin
   c.strip_ansi_escape = true


### PR DESCRIPTION
- [x] Make all the generated bash code compatible with bash strict mode (`set -euo pipefail`).
- [x] Add an environment variable `BASHLY_STRICT`, that if set, will enable strict mode in the script's initialization function
- [x] Set the specs to set `BASHLY_STRICT=1` so that from this point on, all new bash code in bashly will also be compatible.

Closes #113