### PR TITLE
Validate the entire config prior to generating

### DIFF
--- a/lib/bashly/cli.rb
+++ b/lib/bashly/cli.rb
@@ -10,6 +10,7 @@ module Bashly
 
       runner.route 'init',      to: Commands::Init
       runner.route 'preview',   to: Commands::Preview
+      runner.route 'validate',  to: Commands::Validate
       runner.route 'generate',  to: Commands::Generate
       runner.route 'add',       to: Commands::Add
 

--- a/lib/bashly/commands/validate.rb
+++ b/lib/bashly/commands/validate.rb
@@ -1,0 +1,19 @@
+module Bashly
+  module Commands
+    class Validate < Base
+      help "Scan the configuration file for errors"
+
+      usage "bashly validate"
+      usage "bashly validate (-h|--help)"
+
+      environment "BASHLY_SOURCE_DIR", "The path containing the bashly configuration and source files [default: src]"
+
+      def run
+        config = Config.new "#{Settings.source_dir}/bashly.yml"
+        validator = ConfigValidator.new config
+        validator.validate
+        say "!txtgrn!OK"
+      end
+    end
+  end
+end

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -1,0 +1,123 @@
+module Bashly
+  class ConfigValidator
+    attr_reader :data
+
+    def initialize(data)
+      @data = data
+    end
+
+    def validate
+      assert_command "root", data
+    end
+
+  private
+
+    def assert(valid, message)
+      raise ConfigurationError, message unless valid
+    end
+
+    def refute(invalid, message)
+      assert !invalid, message
+    end
+
+    def assert_string(key, value)
+      assert value.is_a?(String), "#{key} must be a string"
+    end
+
+    def assert_boolean(key, value)
+      assert [true, false, nil].include?(value), "#{key} must be a boolean" 
+    end
+
+    def assert_array(key, value, of: nil)
+      return unless value
+      assert value.is_a?(Array), "#{key} must be an array"
+      if of
+        value.each_with_index do |val, i|
+          send "assert_#{of}".to_sym, "#{key}[#{i}]", val
+        end
+      end
+    end
+
+    def assert_hash(key, value)
+      assert value.is_a?(Hash), "#{key} must be a hash"
+    end
+
+    def assert_version(key, value)
+      assert [String, Integer, Float].include?(value.class),
+        "#{key} must be a string or a number" 
+    end
+
+    def assert_catch_all(key, value)
+      return unless value
+      assert [TrueClass, String, Hash].include?(value.class),
+        "#{key} must be a boolean, a string or a hash" 
+    end
+
+    def assert_extensible(key, value)
+      return unless value
+      assert [TrueClass, String].include?(value.class),
+        "#{key} must be a boolean or a string" 
+    end
+
+    def assert_arg(key, value)
+      assert_hash key, value
+      assert_string "#{key}.name", value['name']
+      assert_string "#{key}.help", value['help'] if value['help']
+      assert_string "#{key}.default", value['default'] if value['default']
+      assert_string "#{key}.validate", value['validate'] if value['validate']
+      assert_boolean "#{key}.required", value['required']
+      
+      assert_array "#{key}.allowed", value['allowed'], of: :string
+    end
+
+    def assert_flag(key, value)
+      assert_hash key, value
+      assert value['short'] || value['long'], "#{key} must have at least one of long or short name"
+
+      assert_string "#{key}.long", value['long'] if value['long']
+      assert_string "#{key}.short", value['short'] if value['short']
+      assert_string "#{key}.help", value['help'] if value['help']
+      assert_string "#{key}.arg", value['arg'] if value['arg']
+
+      assert_string "#{key}.default", value['default'] if value['default']
+      assert_string "#{key}.validate", value['validate'] if value['validate']
+      assert_boolean "#{key}.required", value['required']
+      
+      assert_array "#{key}.allowed", value['allowed'], of: :string
+    end
+
+    def assert_env_var(key, value)
+      assert_hash key, value
+      assert_string "#{key}.name", value['name']
+      assert_string "#{key}.help", value['help'] if value['help']
+      assert_string "#{key}.default", value['default'] if value['default']
+      assert_boolean "#{key}.required", value['required']
+    end
+
+    def assert_command(key, value)
+      assert_hash key, value
+
+      refute value['commands'] && value['args'], "#{key} cannot have both commands and args"
+      refute value['commands'] && value['flags'], "#{key} cannot have both commands and flags"
+      
+      assert_string "#{key}.name", value['name']
+      assert_string "#{key}.short", value['short'] if value['short']
+      assert_string "#{key}.help", value['help'] if value['help']
+      assert_string "#{key}.footer", value['footer'] if value['footer']
+      assert_string "#{key}.group", value['group'] if value['group']
+      assert_boolean "#{key}.default", value['default']
+      
+      assert_version "#{key}.version", value['version'] if value['version']
+      assert_catch_all "#{key}.catch_all", value['catch_all']
+      assert_extensible "#{key}.extensible", value['extensible']
+      
+      assert_array "#{key}.args", value['args'], of: :arg
+      assert_array "#{key}.flags", value['flags'] , of: :flag
+      assert_array "#{key}.commands", value['commands'], of: :command
+      assert_array "#{key}.completions", value['completions'], of: :string
+      assert_array "#{key}.dependencies", value['dependencies'], of: :string
+      assert_array "#{key}.environment_variables", value['environment_variables'], of: :env_var
+      assert_array "#{key}.examples", value['examples'], of: :string
+    end
+  end
+end

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -56,6 +56,14 @@ module Bashly
       return unless value
       assert [TrueClass, String, Hash].include?(value.class),
         "#{key} must be a boolean, a string or a hash" 
+
+      assert_catch_all_hash key, value if value.is_a? Hash
+    end
+
+    def assert_catch_all_hash(key, value)
+      assert_string "#{key}.label", value['label']
+      assert_optional_string "#{key}.help", value['help']
+      assert_boolean "#{key}.required", value['required']
     end
 
     def assert_extensible(key, value)

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -24,6 +24,10 @@ module Bashly
       assert value.is_a?(String), "#{key} must be a string"
     end
 
+    def assert_optional_string(key, value)
+      assert_string key, value if value
+    end
+
     def assert_boolean(key, value)
       assert [true, false, nil].include?(value), "#{key} must be a boolean" 
     end
@@ -43,6 +47,7 @@ module Bashly
     end
 
     def assert_version(key, value)
+      return unless value
       assert [String, Integer, Float].include?(value.class),
         "#{key} must be a string or a number" 
     end
@@ -62,9 +67,9 @@ module Bashly
     def assert_arg(key, value)
       assert_hash key, value
       assert_string "#{key}.name", value['name']
-      assert_string "#{key}.help", value['help'] if value['help']
-      assert_string "#{key}.default", value['default'] if value['default']
-      assert_string "#{key}.validate", value['validate'] if value['validate']
+      assert_optional_string "#{key}.help", value['help']
+      assert_optional_string "#{key}.default", value['default']
+      assert_optional_string "#{key}.validate", value['validate']
       assert_boolean "#{key}.required", value['required']
       
       assert_array "#{key}.allowed", value['allowed'], of: :string
@@ -74,23 +79,22 @@ module Bashly
       assert_hash key, value
       assert value['short'] || value['long'], "#{key} must have at least one of long or short name"
 
-      assert_string "#{key}.long", value['long'] if value['long']
-      assert_string "#{key}.short", value['short'] if value['short']
-      assert_string "#{key}.help", value['help'] if value['help']
-      assert_string "#{key}.arg", value['arg'] if value['arg']
-
-      assert_string "#{key}.default", value['default'] if value['default']
-      assert_string "#{key}.validate", value['validate'] if value['validate']
-      assert_boolean "#{key}.required", value['required']
+      assert_optional_string "#{key}.long", value['long']
+      assert_optional_string "#{key}.short", value['short']
+      assert_optional_string "#{key}.help", value['help']
+      assert_optional_string "#{key}.arg", value['arg']
+      assert_optional_string "#{key}.default", value['default']
+      assert_optional_string "#{key}.validate", value['validate']
       
+      assert_boolean "#{key}.required", value['required']
       assert_array "#{key}.allowed", value['allowed'], of: :string
     end
 
     def assert_env_var(key, value)
       assert_hash key, value
       assert_string "#{key}.name", value['name']
-      assert_string "#{key}.help", value['help'] if value['help']
-      assert_string "#{key}.default", value['default'] if value['default']
+      assert_optional_string "#{key}.help", value['help']
+      assert_optional_string "#{key}.default", value['default']
       assert_boolean "#{key}.required", value['required']
     end
 
@@ -101,13 +105,13 @@ module Bashly
       refute value['commands'] && value['flags'], "#{key} cannot have both commands and flags"
       
       assert_string "#{key}.name", value['name']
-      assert_string "#{key}.short", value['short'] if value['short']
-      assert_string "#{key}.help", value['help'] if value['help']
-      assert_string "#{key}.footer", value['footer'] if value['footer']
-      assert_string "#{key}.group", value['group'] if value['group']
+      assert_optional_string "#{key}.short", value['short']
+      assert_optional_string "#{key}.help", value['help']
+      assert_optional_string "#{key}.footer", value['footer']
+      assert_optional_string "#{key}.group", value['group']
+
       assert_boolean "#{key}.default", value['default']
-      
-      assert_version "#{key}.version", value['version'] if value['version']
+      assert_version "#{key}.version", value['version']
       assert_catch_all "#{key}.catch_all", value['catch_all']
       assert_extensible "#{key}.extensible", value['extensible']
       

--- a/lib/bashly/script/argument.rb
+++ b/lib/bashly/script/argument.rb
@@ -4,10 +4,6 @@ module Bashly
       def usage_string
         required ? name.upcase : "[#{name.upcase}]"
       end
-
-      def verify
-        raise ConfigurationError, "Argument must have a name" unless name
-      end
     end
   end
 end

--- a/lib/bashly/script/base.rb
+++ b/lib/bashly/script/base.rb
@@ -33,7 +33,7 @@ module Bashly
       def initialize(options)
         raise Error, "Invalid options provided" unless options.respond_to? :keys
         @options = options
-        verify if respond_to? :verify
+        validate_options if respond_to? :validate_options
       end
 
       def optional

--- a/lib/bashly/script/command.rb
+++ b/lib/bashly/script/command.rb
@@ -36,14 +36,14 @@ module Bashly
 
         if catch_all.is_a? String
           "#{catch_all.upcase}..."
-        elsif catch_all.is_a?(Hash) and catch_all['label'].is_a?(String)
+        elsif catch_all.is_a?(Hash)
           "#{catch_all['label'].upcase}..."
         else
           "..."
         end
       end
 
-      # Returns a used defined help string for the catch_all directive
+      # Returns a user defined help string for the catch_all directive
       def catch_all_help
         return nil unless catch_all
 

--- a/lib/bashly/script/command.rb
+++ b/lib/bashly/script/command.rb
@@ -213,10 +213,9 @@ module Bashly
       end
 
       # Raise an exception if there are some serious issues with the command
-      # definition.
-      def verify
-        verify_commands if commands.any?
-        raise ConfigurationError, "Command must have a name" unless name
+      # definition. This is called by Base#initialize.
+      def validate_options
+        Bashly::ConfigValidator.new(options).validate
       end
 
       # Returns an array of all the args with a whitelist
@@ -227,14 +226,6 @@ module Bashly
       # Returns an array of all the flags with a whitelist arg
       def whitelisted_flags
         flags.select &:allowed
-      end
-
-    private
-
-      def verify_commands
-        if args.any? or flags.any?
-          raise ConfigurationError, "Error in the !txtgrn!#{full_name}!txtrst! command.\nThe !txtgrn!commands!txtrst! key cannot be at the same level as the !txtgrn!args!txtrst! or !txtgrn!flags!txtrst! keys."
-        end
       end
 
     end

--- a/lib/bashly/script/command.rb
+++ b/lib/bashly/script/command.rb
@@ -32,14 +32,11 @@ module Bashly
 
       # Returns a label for the catch_all directive
       def catch_all_label
-        return nil unless catch_all
-
-        if catch_all.is_a? String
-          "#{catch_all.upcase}..."
-        elsif catch_all.is_a?(Hash)
-          "#{catch_all['label'].upcase}..."
-        else
-          "..."
+        case catch_all
+        when nil then nil
+        when String then "#{catch_all.upcase}..."
+        when Hash then "#{catch_all['label'].upcase}..."
+        else "..."
         end
       end
 

--- a/lib/bashly/script/environment_variable.rb
+++ b/lib/bashly/script/environment_variable.rb
@@ -6,10 +6,6 @@ module Bashly
         result << strings[:required] if required and extended
         result.join " "
       end
-
-      def verify
-        raise ConfigurationError, "EnvironmentVariable must have a name" unless name
-      end
     end
   end
 end

--- a/lib/bashly/script/flag.rb
+++ b/lib/bashly/script/flag.rb
@@ -21,11 +21,6 @@ module Bashly
         result << strings[:required] if required and extended
         result.join " "
       end
-
-      def verify
-        raise ConfigurationError, "Flag must have a long and/or short property" unless short or long
-      end
-
     end
   end
 end

--- a/spec/approvals/cli/commands
+++ b/spec/approvals/cli/commands
@@ -3,5 +3,6 @@ Bashly - Bash CLI Generator
 Commands:
   init      Initialize a new workspace
   preview   Generate the bash script to STDOUT
+  validate  Scan the configuration file for errors
   generate  Generate the bash script and required files
   add       Add extra features and customization to your script

--- a/spec/approvals/cli/validate/help
+++ b/spec/approvals/cli/validate/help
@@ -1,0 +1,13 @@
+Scan the configuration file for errors
+
+Usage:
+  bashly validate
+  bashly validate (-h|--help)
+
+Options:
+  -h --help
+    Show this help
+
+Environment Variables:
+  BASHLY_SOURCE_DIR
+    The path containing the bashly configuration and source files [default: src]

--- a/spec/approvals/validations/commands_and_args
+++ b/spec/approvals/validations/commands_and_args
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root cannot have both commands and args>

--- a/spec/approvals/validations/commands_and_flags
+++ b/spec/approvals/validations/commands_and_flags
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root cannot have both commands and flags>

--- a/spec/approvals/validations/extensible
+++ b/spec/approvals/validations/extensible
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.extensible must be a boolean or a string>

--- a/spec/approvals/validations/nested
+++ b/spec/approvals/validations/nested
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.commands[0].commands[1].args[1].name must be a string>

--- a/spec/approvals/validations/no_name
+++ b/spec/approvals/validations/no_name
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.name must be a string>

--- a/spec/bashly/commands/validate_spec.rb
+++ b/spec/bashly/commands/validate_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Commands::Validate do
+  let(:source_dir) { Settings.source_dir }
+  subject { CLI.runner }
+
+  context "with --help" do
+    it "shows long usage" do
+      expect{ subject.run %w[validate --help] }.to output_approval('cli/validate/help')
+    end
+  end
+
+  context "without arguments" do
+    before do
+      reset_tmp_dir
+      success = system "mkdir -p #{source_dir} && cp lib/bashly/templates/bashly.yml #{source_dir}/bashly.yml"
+      expect(success).to be true
+    end
+
+    it "validates the script" do
+      expect { subject.run %w[validate] }.to output("OK\n").to_stdout
+    end
+  end
+
+end

--- a/spec/bashly/config_validator_spec.rb
+++ b/spec/bashly/config_validator_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe ConfigValidator do
+  fixtures = load_fixture 'script/validations'
+  subject { described_class.new options }
+
+  describe '#validate' do
+    fixtures.each do |fixture, options|
+      context "with :#{fixture}" do
+        let(:options) { options }
+        
+        it "raises an error" do
+          expect { subject.validate }.to raise_approval("validations/#{fixture}")
+        end
+      end
+    end
+  end
+
+end

--- a/spec/bashly/script/argument_spec.rb
+++ b/spec/bashly/script/argument_spec.rb
@@ -21,15 +21,4 @@ describe Script::Argument do
       end
     end
   end
-
-  describe '#verify' do
-    context "when the argument has no name" do
-      let(:fixture) { :invalid_without_name }
-
-      it "raises an error" do
-        expect { subject.verify }.to raise_error(ConfigurationError, /must have a name/)
-      end
-    end
-  end
-
 end

--- a/spec/bashly/script/command_spec.rb
+++ b/spec/bashly/script/command_spec.rb
@@ -394,29 +394,15 @@ describe Script::Command do
     end
   end
 
-  describe '#verify' do
-    context "when commands and flags are present" do
-      let(:fixture) { :invalid_with_flags }
+  describe '#validate_options' do
+    let(:validator_double) { double :validator, validate: "ok" }
 
-      it "raises an error" do
-        expect { subject.verify }.to raise_error(ConfigurationError, /cannot be at the same level/)
-      end
-    end
+    it "delegates to Bashly::ConfigValidator" do
+      expect(Bashly::ConfigValidator).to receive(:new).with(subject.options)
+        .and_return(validator_double)
+      expect(validator_double).to receive(:validate)
 
-    context "when commands and args are present" do
-      let(:fixture) { :invalid_with_args }
-
-      it "raises an error" do
-        expect { subject.verify }.to raise_error(ConfigurationError, /cannot be at the same level/)
-      end
-    end
-
-    context "when the command has no name" do
-      let(:fixture) { :invalid_without_name }
-
-      it "raises an error" do
-        expect { subject.verify }.to raise_error(ConfigurationError, /must have a name/)
-      end
+      subject.validate_options
     end
   end
 

--- a/spec/bashly/script/flag_spec.rb
+++ b/spec/bashly/script/flag_spec.rb
@@ -79,15 +79,4 @@ describe Script::Flag do
     end
   end
 
-  describe '#verify' do
-    context "when the flag has no short or long" do
-      let(:fixture) { :invalid_without_name }
-
-      it "raises an error" do
-        expect { subject.verify }.to raise_error(ConfigurationError, /must have a long and\/or short property/)
-      end
-    end
-  end
-
-
 end

--- a/spec/fixtures/script/arguments.yml
+++ b/spec/fixtures/script/arguments.yml
@@ -4,6 +4,3 @@
 :required:
   name: file
   required: true
-
-:invalid_without_name:
-  help: invalid since there is no name

--- a/spec/fixtures/script/commands.yml
+++ b/spec/fixtures/script/commands.yml
@@ -55,25 +55,6 @@
 :helpless:
   name: helpless
 
-:invalid_with_args:
-  name: invalid
-  help: invalid since there are both commands and args
-  commands:
-  - name: sub
-  args:
-  - name: source
-
-:invalid_with_flags:
-  name: invalid
-  help: invalid since there are both commands and flags
-  commands:
-  - name: sub
-  flags:
-  - long: --force
-
-:invalid_without_name:
-  help: invalid since there is no name
-
 :default_command:
   name: cli
   commands:

--- a/spec/fixtures/script/flags.yml
+++ b/spec/fixtures/script/flags.yml
@@ -12,6 +12,3 @@
 :required:
   long: --mandatory
   required: true
-
-:invalid_without_name:
-  help: invalid since there is no name

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -1,0 +1,38 @@
+:commands_and_args:
+  name: invalid
+  help: invalid since there are both commands and args
+  commands:
+  - name: sub
+  args:
+  - name: source
+
+:commands_and_flags:
+  name: invalid
+  help: invalid since there are both commands and flags
+  commands:
+  - name: sub
+  flags:
+  - long: --force
+
+:no_name:
+  help: invalid since there is no name
+
+:extensible:
+  name: invalid
+  help: invalid since extensible shuold be a boolean or string
+  extensible: 1
+
+:nested:
+  name: invalid
+  commands:
+    - name: level1
+      commands:
+        - name: level2a
+          args:
+            - name: ok
+            - name: alright
+        - name: level2b
+          args:          
+            - name: ok
+            - help: invalid since there is no name
+


### PR DESCRIPTION
- Improve validation of config file
- Run validation prior to running `bashly generate`
- Add `bashly validate` command to just run validation

Validation errors will show the full data-structure path, like so:

```
root.commands[0].commands[1].args[1].name must be a string
```

Closes #158