### PR TITLE
Fix whitelist filter on repeatable flags

### DIFF
--- a/lib/bashly/views/command/whitelist_filter.erb
+++ b/lib/bashly/views/command/whitelist_filter.erb
@@ -6,8 +6,18 @@ if [[ ! ${args[<%= arg.name %>]} =~ ^(<%= arg.allowed.join '|' %>)$ ]]; then
 fi
 % end
 % whitelisted_flags.each do |flag|
+% if flag.repeatable
+eval "input_array=(${args[<%= flag.name %>]})"
+for i in "${input_array[@]}"; do
+  if [[ ! $i =~ ^(<%= flag.allowed.join '|' %>)$ ]]; then
+    printf "%s\n" "<%= strings[:disallowed_flag] % { name: flag.name, allowed: flag.allowed.join(', ') } %>"
+    exit 1
+  fi
+done
+% else
 if [[ ! ${args[<%= flag.name %>]} =~ ^(<%= flag.allowed.join '|' %>)$ ]]; then
   printf "%s\n" "<%= strings[:disallowed_flag] % { name: flag.name, allowed: flag.allowed.join(', ') } %>"
   exit 1
 fi
+% end
 % end

--- a/spec/approvals/fixtures/repeatable-whitelist
+++ b/spec/approvals/fixtures/repeatable-whitelist
@@ -1,0 +1,27 @@
++ bundle exec bashly generate
+creating user files in src
+created src/initialize.sh
+created src/root_command.sh
+created ./download
+run ./download --help to test your bash script
++ ./download
+# this file is located in 'src/root_command.sh'
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[--protocol]} = ftp
++ ./download -p ssh
+# this file is located in 'src/root_command.sh'
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[--protocol]} = "ssh"
++ ./download -p ssh -p ftp
+# this file is located in 'src/root_command.sh'
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[--protocol]} = "ssh" "ftp"
++ ./download -p sftp -p https
+--protocol must be one of: ssh, ftp, sftp
++ ./download -p http -p ftp
+--protocol must be one of: ssh, ftp, sftp
++ ./download --protocol telnet
+--protocol must be one of: ssh, ftp, sftp

--- a/spec/fixtures/workspaces/repeatable-whitelist/.gitignore
+++ b/spec/fixtures/workspaces/repeatable-whitelist/.gitignore
@@ -1,0 +1,2 @@
+download
+src/*.sh

--- a/spec/fixtures/workspaces/repeatable-whitelist/README.md
+++ b/spec/fixtures/workspaces/repeatable-whitelist/README.md
@@ -1,0 +1,2 @@
+This fixture tests that `flag.repeatable` does not break `flag.allowed`
+Reference issue: https://github.com/DannyBen/bashly/issues/187

--- a/spec/fixtures/workspaces/repeatable-whitelist/src/bashly.yml
+++ b/spec/fixtures/workspaces/repeatable-whitelist/src/bashly.yml
@@ -1,0 +1,12 @@
+name: download
+help: Test that repeatable does not break allowed
+version: 0.1.0
+
+flags:
+- long: --protocol
+  short: -p
+  help: Choose protocol
+  arg: protocol
+  allowed: [ssh, ftp, sftp]
+  default: ftp
+  repeatable: true

--- a/spec/fixtures/workspaces/repeatable-whitelist/test.sh
+++ b/spec/fixtures/workspaces/repeatable-whitelist/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This fixture tests that the config lib scope bug
+# It is executed as part of the Runfile examples test
+# Reference issue: https://github.com/DannyBen/bashly/issues/107
+
+rm -f ./download
+rm -f ./src/initialize.sh
+rm -f ./src/root_command.sh
+
+set -x
+
+bundle exec bashly generate
+
+./download
+./download -p ssh
+./download -p ssh -p ftp
+./download -p sftp -p https
+./download -p http -p ftp
+./download --protocol telnet


### PR DESCRIPTION
Changed the whitelist (`allowed`) filter for a flag in case it is also `repeatable` so that the filter dissects the array that is represented as a space delimited string, and checks that all input values match the allowed list.

Closes #187