### PR TITLE
Remove `--version` from subcommands

### DIFF
--- a/lib/bashly/views/command/fixed_flags_filter.erb
+++ b/lib/bashly/views/command/fixed_flags_filter.erb
@@ -1,5 +1,6 @@
 # :command.fixed_flag_filter
 case "${1:-}" in
+% if root_command?
 % if short_flag_exist? "-v"
 --version )
 % else
@@ -9,6 +10,7 @@ case "${1:-}" in
   exit
   ;;
 
+% end
 % if short_flag_exist? "-h"
 --help )
 % else

--- a/spec/approvals/fixtures/version-in-subcommands
+++ b/spec/approvals/fixtures/version-in-subcommands
@@ -1,0 +1,41 @@
++ bundle exec bashly generate
+creating user files in src
+created src/initialize.sh
+created src/git_command.sh
+created ./cli
+run ./cli --help to test your bash script
++ ./cli --version
+1.2.3
++ ./cli help
+cli - Sample application
+
+Usage:
+  cli [command]
+  cli [command] --help | -h
+  cli --version | -v
+
+Commands:
+  git   Delegate to git
+
++ ./cli git --version
+# this file is located in 'src/git_command.sh'
+# code for 'cli git' goes here
+# you can edit it freely and regenerate (it will not be overwritten)
+args: none
+
+other_args:
+- ${other_args[*]} = --version
+- ${other_args[0]} = --version
++ ./cli git any 'other args' -or --flags
+# this file is located in 'src/git_command.sh'
+# code for 'cli git' goes here
+# you can edit it freely and regenerate (it will not be overwritten)
+args: none
+
+other_args:
+- ${other_args[*]} = any other args -o -r --flags
+- ${other_args[0]} = any
+- ${other_args[1]} = other args
+- ${other_args[2]} = -o
+- ${other_args[3]} = -r
+- ${other_args[4]} = --flags

--- a/spec/fixtures/workspaces/version-in-subcommands/.gitignore
+++ b/spec/fixtures/workspaces/version-in-subcommands/.gitignore
@@ -1,0 +1,2 @@
+src/*.sh
+cli

--- a/spec/fixtures/workspaces/version-in-subcommands/README.md
+++ b/spec/fixtures/workspaces/version-in-subcommands/README.md
@@ -1,0 +1,2 @@
+This fixture tests that somcommands do not handle the --version flag
+ref: https://github.com/DannyBen/bashly/discussions/197

--- a/spec/fixtures/workspaces/version-in-subcommands/src/bashly.yml
+++ b/spec/fixtures/workspaces/version-in-subcommands/src/bashly.yml
@@ -1,0 +1,8 @@
+name: cli
+help: Sample application
+version: 1.2.3
+
+commands:
+- name: git
+  help: Delegate to git
+  catch_all: git_params

--- a/spec/fixtures/workspaces/version-in-subcommands/test.sh
+++ b/spec/fixtures/workspaces/version-in-subcommands/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+rm -f ./src/*.sh
+
+set -x
+
+bundle exec bashly generate
+
+./cli --version
+./cli help
+./cli git --version
+./cli git any "other args" -or --flags


### PR DESCRIPTION
Subcommands should not handle `--version`.

Discussion: https://github.com/DannyBen/bashly/discussions/197