### PR TITLE
Add deprecation warning for `command.short`

### DIFF
--- a/lib/bashly/commands/base.rb
+++ b/lib/bashly/commands/base.rb
@@ -17,6 +17,18 @@ module Bashly
       def validate_config
         config_validator.validate
       end
+
+      def with_valid_config
+        validate_config
+        yield
+        show_deprecations
+      end
+
+      def show_deprecations
+        return if config_validator.deprecations.empty? or ENV['BASHLY_HIDE_DEPRECATIONS']
+        messages = "\n" + config_validator.deprecations.map(&:message).join("\n\n") + "\n\n"
+        say! messages
+      end
     end
   end
 end

--- a/lib/bashly/commands/base.rb
+++ b/lib/bashly/commands/base.rb
@@ -6,10 +6,16 @@ module Bashly
     class Base < MisterBin::Command
       include AssetHelper
 
+      def config
+        @config ||= Config.new "#{Settings.source_dir}/bashly.yml"
+      end
+
+      def config_validator
+        @config_validator ||= ConfigValidator.new config
+      end
+
       def validate_config
-        config = Config.new "#{Settings.source_dir}/bashly.yml"
-        validator = ConfigValidator.new config
-        validator.validate
+        config_validator.validate
       end
     end
   end

--- a/lib/bashly/commands/generate.rb
+++ b/lib/bashly/commands/generate.rb
@@ -29,13 +29,14 @@ module Bashly
       example "bashly generate --wrap my_function"
 
       def run
-        validate_config
-        Settings.env = args['--env'] if args['--env']
-        quiet_say "creating !txtgrn!production!txtrst! version" if Settings.production?
-        create_user_files
-        upgrade_libs if args['--upgrade']
-        create_master_script
-        quiet_say "run !txtpur!#{master_script_path} --help!txtrst! to test your bash script"
+        with_valid_config do
+          Settings.env = args['--env'] if args['--env']
+          quiet_say "creating !txtgrn!production!txtrst! version" if Settings.production?
+          create_user_files
+          upgrade_libs if args['--upgrade']
+          create_master_script
+          quiet_say "run !txtpur!#{master_script_path} --help!txtrst! to test your bash script"
+        end
       end
 
     private

--- a/lib/bashly/commands/generate.rb
+++ b/lib/bashly/commands/generate.rb
@@ -32,9 +32,7 @@ module Bashly
         with_valid_config do
           Settings.env = args['--env'] if args['--env']
           quiet_say "creating !txtgrn!production!txtrst! version" if Settings.production?
-          create_user_files
-          upgrade_libs if args['--upgrade']
-          create_master_script
+          generate_all_files
           quiet_say "run !txtpur!#{master_script_path} --help!txtrst! to test your bash script"
         end
       end
@@ -43,6 +41,12 @@ module Bashly
 
       def quiet_say(message)
         say message unless args['--quiet']
+      end
+
+      def generate_all_files
+        create_user_files
+        upgrade_libs if args['--upgrade']
+        create_master_script
       end
 
       def upgrade_libs

--- a/lib/bashly/commands/generate.rb
+++ b/lib/bashly/commands/generate.rb
@@ -128,10 +128,6 @@ module Bashly
         "#{Settings.target_dir}/#{command.name}"
       end
 
-      def config
-        @config ||= Config.new "#{Settings.source_dir}/bashly.yml"
-      end
-
       def command
         @command ||= Script::Command.new config
       end

--- a/lib/bashly/commands/preview.rb
+++ b/lib/bashly/commands/preview.rb
@@ -9,8 +9,8 @@ module Bashly
       environment "BASHLY_SOURCE_DIR", "The path containing the bashly configuration and source files [default: src]"
 
       def run
-        config = Config.new "#{Settings.source_dir}/bashly.yml"
-        command = Script::Command.new(config)
+        validate_config
+        command = Script::Command.new config
         script = Script::Wrapper.new command
         puts script.code
       end

--- a/lib/bashly/commands/preview.rb
+++ b/lib/bashly/commands/preview.rb
@@ -9,10 +9,11 @@ module Bashly
       environment "BASHLY_SOURCE_DIR", "The path containing the bashly configuration and source files [default: src]"
 
       def run
-        validate_config
-        command = Script::Command.new config
-        script = Script::Wrapper.new command
-        puts script.code
+        with_valid_config do
+          command = Script::Command.new config
+          script = Script::Wrapper.new command
+          puts script.code
+        end
       end
     end
   end

--- a/lib/bashly/commands/validate.rb
+++ b/lib/bashly/commands/validate.rb
@@ -10,7 +10,13 @@ module Bashly
 
       def run
         validate_config
-        say "!txtgrn!OK"
+        show_deprecations
+        deprecations = config_validator.deprecations
+        if deprecations.empty?
+          say "!txtgrn!OK"
+        else
+          say "!txtred!WARNING!txtrst! Found #{deprecations.count} deprecations"
+        end
       end
     end
   end

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -10,6 +10,10 @@ module Bashly
       assert_command "root", data
     end
 
+    def deprecations
+      @deprecations ||= []
+    end
+
   private
 
     def assert(valid, message)
@@ -18,6 +22,10 @@ module Bashly
 
     def refute(invalid, message)
       assert !invalid, message
+    end
+
+    def deprecate(key, **options)
+      deprecations.push Deprecation.new(key, **options)
     end
 
     def assert_string(key, value)
@@ -182,6 +190,11 @@ module Bashly
       else
         refute value['version'], "#{key}.version makes no sense"
         refute value['extensible'], "#{key}.extensible makes no sense"
+      end
+
+      # DEPRECATION 0.8.0
+      if value['short']
+        deprecate "#{key}.short", replacement: "alias", reference: "https://github.com/DannyBen/bashly/pull/220"
       end
     end
   end

--- a/lib/bashly/deprecation.rb
+++ b/lib/bashly/deprecation.rb
@@ -1,0 +1,25 @@
+module Bashly
+  class Deprecation
+    attr_reader :old, :replacement, :reference
+
+    def initialize(old, replacement: nil, reference: nil)
+      @old, @replacement, @reference = old, replacement, reference
+    end
+
+    def message
+      result = ["Deprecation Warning:", "!txtred!#{old}!txtrst! is deprecated"]
+      result.push "use !txtgrn!#{replacement}!txtrst! instead" if replacement
+      result.push "see !undblu!#{reference}!txtrst!" if reference
+      
+      result.map { |line| "!txtred!▐!txtrst! #{line}"}.join("\n")
+    end
+
+    def to_h
+      {
+        old: old,
+        replacement: replacement,
+        reference: reference
+      }
+    end
+  end
+end

--- a/lib/bashly/script/command.rb
+++ b/lib/bashly/script/command.rb
@@ -12,7 +12,9 @@ module Bashly
             extensible filename filters flags
             footer group help name
             private version
+            short
           ]
+          # DEPRECATION 0.8.0
         end
       end
 
@@ -32,6 +34,8 @@ module Bashly
 
       # Returns an array of alternative aliases if any
       def alt
+        # DEPRECATION 0.8.0
+        options['alias'] ||= options['short']
         return [] unless options["alias"]
         options['alias'].is_a?(String) ? [options['alias']] : options['alias']
       end

--- a/spec/approvals/cli/deprecations/command-short-stderr
+++ b/spec/approvals/cli/deprecations/command-short-stderr
@@ -1,0 +1,11 @@
+
+▐ Deprecation Warning:
+▐ root.commands[0].short is deprecated
+▐ use alias instead
+▐ see https://github.com/DannyBen/bashly/pull/220
+
+▐ Deprecation Warning:
+▐ root.commands[1].short is deprecated
+▐ use alias instead
+▐ see https://github.com/DannyBen/bashly/pull/220
+

--- a/spec/approvals/cli/validate/deprecation-command-short
+++ b/spec/approvals/cli/validate/deprecation-command-short
@@ -1,0 +1,1 @@
+WARNING Found 2 deprecations

--- a/spec/approvals/deprecation/message
+++ b/spec/approvals/deprecation/message
@@ -1,0 +1,4 @@
+!txtred!▐!txtrst! Deprecation Warning:
+!txtred!▐!txtrst! !txtred!old!txtrst! is deprecated
+!txtred!▐!txtrst! use !txtgrn!new!txtrst! instead
+!txtred!▐!txtrst! see !undblu!https://somewhere!txtrst!

--- a/spec/approvals/fixtures/deprecation-command-short
+++ b/spec/approvals/fixtures/deprecation-command-short
@@ -1,0 +1,44 @@
++ bundle exec bashly generate
+
+▐ Deprecation Warning:
+▐ root.commands[0].short is deprecated
+▐ use alias instead
+▐ see https://github.com/DannyBen/bashly/pull/220
+
+▐ Deprecation Warning:
+▐ root.commands[1].short is deprecated
+▐ use alias instead
+▐ see https://github.com/DannyBen/bashly/pull/220
+
+creating user files in src
+created src/initialize.sh
+created src/download_command.sh
+created src/upload_command.sh
+created ./cli
+run ./cli --help to test your bash script
++ ./cli upload --help
+cli upload
+
+Alias: u
+
+Usage:
+  cli upload
+  cli upload --help | -h
+
+Options:
+  --help, -h
+    Show this help
+
++ ./cli download --help
+cli download
+
+Alias: d
+
+Usage:
+  cli download
+  cli download --help | -h
+
+Options:
+  --help, -h
+    Show this help
+

--- a/spec/approvals/script/deprecations/command_short
+++ b/spec/approvals/script/deprecations/command_short
@@ -1,0 +1,4 @@
+---
+- :old: root.commands[0].short
+  :replacement: alias
+  :reference: https://github.com/DannyBen/bashly/pull/220

--- a/spec/bashly/commands/generate_spec.rb
+++ b/spec/bashly/commands/generate_spec.rb
@@ -16,9 +16,8 @@ describe Commands::Generate do
     let(:cli_script) { "#{target_dir}/cli" }
 
     before do
-      reset_tmp_dir
-      success = system "mkdir -p #{source_dir} && cp lib/bashly/templates/bashly.yml #{source_dir}/bashly.yml"
-      expect(success).to be true
+      reset_tmp_dir create_src: true
+      cp "lib/bashly/templates/bashly.yml", "#{source_dir}/bashly.yml"
     end
 
     it "generates the cli script" do
@@ -80,9 +79,8 @@ describe Commands::Generate do
     let(:cli_script) { "#{target_dir}/cli" }
 
     before do
-      reset_tmp_dir
-      success = system "mkdir -p #{source_dir} && cp lib/bashly/templates/bashly.yml #{source_dir}/bashly.yml"
-      expect(success).to be true
+      reset_tmp_dir create_src: true
+      cp "lib/bashly/templates/bashly.yml", "#{source_dir}/bashly.yml"
     end
 
     it "generates the cli script" do
@@ -95,9 +93,8 @@ describe Commands::Generate do
     let(:cli_script) { "#{target_dir}/cli" }
 
     before do
-      reset_tmp_dir
-      success = system "mkdir -p #{source_dir} && cp lib/bashly/templates/bashly.yml #{source_dir}/bashly.yml"
-      expect(success).to be true
+      reset_tmp_dir create_src: true
+      cp "lib/bashly/templates/bashly.yml", "#{source_dir}/bashly.yml"
     end
 
     it "generates the cli script wrapped in a function without bash3 bouncer" do
@@ -113,9 +110,8 @@ describe Commands::Generate do
     let(:cli_script_content) { File.read cli_script }
 
     before do
-      reset_tmp_dir
-      success = system "mkdir -p #{source_dir} && cp lib/bashly/templates/bashly.yml #{source_dir}/bashly.yml"
-      expect(success).to be true
+      reset_tmp_dir create_src: true
+      cp "lib/bashly/templates/bashly.yml", "#{source_dir}/bashly.yml"
     end
 
     after  { Settings.env = nil }
@@ -132,7 +128,8 @@ describe Commands::Generate do
     let(:outdated_text) { "OUTDATED TEXT" }
 
     before do
-      reset_tmp_dir copy_from: 'spec/fixtures/workspaces/lib-upgrade'
+      reset_tmp_dir
+      cp 'spec/fixtures/workspaces/lib-upgrade/*'
     end
 
     it "claims to upgrade all upgradable libraries" do
@@ -202,6 +199,18 @@ describe Commands::Generate do
         expect { subject.run %w[generate -u] }.to output_approval('cli/generate/upgrade-unknown-lib')
       end
     end
-
   end
+
+  # DEPRECATION 0.8.0
+  context "with deprecated command.short option" do
+    before do
+      reset_tmp_dir create_src: true
+      cp "spec/fixtures/deprecations/command-short.yml", "#{source_dir}/bashly.yml"
+    end
+
+    it "shows deprecations messages in stderr" do
+      expect { subject.run %w[generate] }.to output_approval('cli/deprecations/command-short-stderr').to_stderr
+    end
+  end
+
 end

--- a/spec/bashly/commands/preview_spec.rb
+++ b/spec/bashly/commands/preview_spec.rb
@@ -12,14 +12,25 @@ describe Commands::Preview do
 
   context "without arguments" do
     before do
-      reset_tmp_dir
-      success = system "mkdir -p #{source_dir} && cp lib/bashly/templates/bashly.yml #{source_dir}/bashly.yml"
-      expect(success).to be true
+      reset_tmp_dir create_src: true
+      cp "lib/bashly/templates/bashly.yml", "#{source_dir}/bashly.yml"
     end
 
     it "prints the generated cli script" do
       expect { subject.run %w[preview] }.to output_approval('cli/preview/no-args')
         .except(/env bash\n.*\nrun "\$@"/m, "env bash\n...\nrun \"\$@\"")
+    end
+  end
+
+  # DEPRECATION 0.8.0
+  context "with deprecated command.short option" do
+    before do
+      reset_tmp_dir create_src: true
+      cp "spec/fixtures/deprecations/command-short.yml", "#{source_dir}/bashly.yml"
+    end
+
+    it "shows deprecations messages in stderr" do
+      expect { subject.run %w[preview] }.to output_approval('cli/deprecations/command-short-stderr').to_stderr
     end
   end
 

--- a/spec/bashly/commands/validate_spec.rb
+++ b/spec/bashly/commands/validate_spec.rb
@@ -12,9 +12,8 @@ describe Commands::Validate do
 
   context "without arguments" do
     before do
-      reset_tmp_dir
-      success = system "mkdir -p #{source_dir} && cp lib/bashly/templates/bashly.yml #{source_dir}/bashly.yml"
-      expect(success).to be true
+      reset_tmp_dir create_src: true
+      cp "lib/bashly/templates/bashly.yml", "#{source_dir}/bashly.yml"
     end
 
     it "validates the script" do
@@ -22,4 +21,19 @@ describe Commands::Validate do
     end
   end
 
+  # DEPRECATION 0.8.0
+  context "with deprecated command.short option" do
+    before do
+      reset_tmp_dir create_src: true
+      cp "spec/fixtures/deprecations/command-short.yml", "#{source_dir}/bashly.yml"
+    end
+
+    it "shows deprecations count in stdout" do
+      expect { subject.run %w[validate] }.to output_approval('cli/validate/deprecation-command-short')
+    end
+
+    it "shows deprecations messages in stderr" do
+      expect { subject.run %w[validate] }.to output_approval('cli/deprecations/command-short-stderr').to_stderr
+    end
+  end
 end

--- a/spec/bashly/config_validator_spec.rb
+++ b/spec/bashly/config_validator_spec.rb
@@ -8,9 +8,27 @@ describe ConfigValidator do
     fixtures.each do |fixture, options|
       context "with :#{fixture}" do
         let(:options) { options }
-        
+
         it "raises an error" do
           expect { subject.validate }.to raise_approval("validations/#{fixture}")
+        end
+      end
+    end
+  end
+
+  context "deprecations" do
+    fixtures = load_fixture 'script/deprecations'
+
+    describe '#validate' do
+      fixtures.each do |fixture, options|
+        context "with :#{fixture}" do
+          let(:options) { options }
+
+          it "stores deprecations" do
+            subject.validate
+            deprecations = subject.deprecations.map(&:to_h).to_yaml
+            expect(deprecations).to match_approval("script/deprecations/#{fixture}")
+          end
         end
       end
     end

--- a/spec/bashly/deprecation_spec.rb
+++ b/spec/bashly/deprecation_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Deprecation do
+  subject { described_class.new old, **options }
+  let(:old) { 'old' }
+  let(:options) { {replacement: 'new', reference: 'https://somewhere' } }
+
+  describe '#message' do
+    it "returns a nicey formatted deprecation string" do
+      expect(subject.message).to match_approval('deprecation/message')
+    end
+  end
+end

--- a/spec/bashly/deprecation_spec.rb
+++ b/spec/bashly/deprecation_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Deprecation do
   subject { described_class.new old, **options }
   let(:old) { 'old' }
-  let(:options) { {replacement: 'new', reference: 'https://somewhere' } }
+  let(:options) { { replacement: 'new', reference: 'https://somewhere' } }
 
   describe '#message' do
     it "returns a nicey formatted deprecation string" do

--- a/spec/bashly/libraries/completions_function_spec.rb
+++ b/spec/bashly/libraries/completions_function_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Libraries::CompletionsFunction do
   subject { described_class.new *args }
   let(:args) { nil }
-  before { reset_tmp_dir copy_from: 'examples/minimal'}
+  before { reset_tmp_dir example: 'minimal'}
 
   describe '#files' do
     it "returns an array with a single hash" do

--- a/spec/bashly/libraries/completions_script_spec.rb
+++ b/spec/bashly/libraries/completions_script_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Libraries::CompletionsScript do
   subject { described_class.new *args }
   let(:args) { nil }
-  before { reset_tmp_dir copy_from: 'examples/minimal'}
+  before { reset_tmp_dir example: 'minimal'}
 
   describe '#files' do
     it "returns an array with a single hash" do

--- a/spec/bashly/libraries/completions_yaml_spec.rb
+++ b/spec/bashly/libraries/completions_yaml_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Libraries::CompletionsYAML do
   subject { described_class.new *args }
   let(:args) { nil }
-  before { reset_tmp_dir copy_from: 'examples/minimal'}
+  before { reset_tmp_dir example: 'minimal'}
 
   describe '#files' do
     it "returns an array with a single hash" do

--- a/spec/bashly/library_spec.rb
+++ b/spec/bashly/library_spec.rb
@@ -44,7 +44,7 @@ describe Library do
 
     context "for libraries with a custom handler" do
       let(:name) { "completions" }
-      before { reset_tmp_dir copy_from: 'examples/minimal'}
+      before { reset_tmp_dir example: 'minimal' }
 
       it "delegaes the request to a custom handler" do
         expect(subject.files).to be_an Array
@@ -72,7 +72,7 @@ describe Library do
 
     context "for libraries with a custom handler" do
       let(:name) { "completions_yaml" }
-      before { reset_tmp_dir copy_from: 'examples/minimal'}
+      before { reset_tmp_dir example: 'minimal'}
 
       it "returns the message form the handler" do
         expect(subject.post_install_message).to include "completely"

--- a/spec/bashly/message_strings_spec.rb
+++ b/spec/bashly/message_strings_spec.rb
@@ -13,8 +13,7 @@ describe MessageStrings do
 
     before do
       reset_tmp_dir create_src: true
-      success = system "cp #{config_template} #{userspace}"
-      expect(success).to be true
+      cp config_template, userspace
     end
 
     it "returns values from the user config, falling back to defaults" do

--- a/spec/fixtures/deprecations/command-short.yml
+++ b/spec/fixtures/deprecations/command-short.yml
@@ -1,0 +1,9 @@
+name: cli
+help: Testing command.short deprecations
+version: 0.1.0
+
+commands:
+  - name: download
+    short: d
+  - name: upload
+    short: u

--- a/spec/fixtures/script/deprecations.yml
+++ b/spec/fixtures/script/deprecations.yml
@@ -1,0 +1,7 @@
+# DEPRECATION 0.8.0
+:command_short:
+  name: invalid
+  help: command.short is deprecated, use alias instead
+  commands:
+  - name: download
+    short: d

--- a/spec/spec_mixin.rb
+++ b/spec/spec_mixin.rb
@@ -1,13 +1,17 @@
 module SpecMixin
-  def reset_tmp_dir(create_src: false, copy_from: nil)
+  def reset_tmp_dir(create_src: false, example: nil)
     system 'rm -rf spec/tmp/*'
     system 'mkdir -p spec/tmp'
     system 'mkdir -p spec/tmp/src' if create_src
-    system "cp -r #{copy_from}/* spec/tmp/" if copy_from
+    cp "examples/#{example}/*" if example
   end
 
   def load_fixture(filename)
     @loaded_fixtures ||= {}
     @loaded_fixtures[filename] ||= YAML.properly_load_file("spec/fixtures/#{filename}.yml")
+  end
+
+  def cp(source, target = 'spec/tmp/')
+    expect(system "cp -r #{source} #{target}").to be true
   end
 end


### PR DESCRIPTION
This PR adds a deprecation mechanism, so that we can present breaking changes to the users softly (for example #220).

### Changes from user perspective

- Running `bashly generate`, `bashly preview` or `bashly validate` will show a clear deprecation warning for each `command.short` occurrence in the config.
- The deprecated `command.short` directive is still going to be allowed for a short period of time.

### Changes from developer perspective

- Added `Deprecation` class
- Added `ConfigValidator#deprecate` to allow marking future deprecations with ease
- Added `Command::Base#with_valid_config` block handler to streamline all the command handlers that require a valid configuration. This method will validate, then yield to the block, then show deprecation warnings if any.
- `command.short` is treated as if it was `command.alias`
- All pieces of code that were added just for the sake of the 0.8.0 deprecations were marked as such with `# DEPRECATION 0.8.0`

In addition, this PR is a little dirty since there was some refactoring done to tmp dir management for the specs.
