### PR TITLE
Improve non-unique command validation by testing name and aliases together

### DIFF
--- a/lib/bashly/concerns/validation_helpers.rb
+++ b/lib/bashly/concerns/validation_helpers.rb
@@ -52,10 +52,16 @@ module Bashly
       end
     end
 
-    def assert_uniq(key, value, array_key)
+    def assert_uniq(key, value, array_keys)
       return unless value
-      list = value.map { |c| c[array_key] }.compact.flatten
-      assert list.uniq?, "#{key} cannot have elements with similar #{array_key} values"
+      array_keys = [array_keys] unless array_keys.is_a? Array
+      list = []
+      array_keys.each do |array_key|
+        list += value.map { |c| c[array_key] }.compact.flatten
+      end
+
+      nonuniqs = list.nonuniq
+      assert nonuniqs.empty?, "#{key} contains non-unique elements (#{nonuniqs.join ', '}) in #{array_keys.join ' or '}"
     end
 
     def assert_string_or_array(key, value)

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -124,8 +124,7 @@ module Bashly
       assert_array "#{key}.environment_variables", value['environment_variables'], of: :env_var
       assert_array "#{key}.examples", value['examples'], of: :string
 
-      assert_uniq "#{key}.commands", value['commands'], 'name'
-      assert_uniq "#{key}.commands", value['commands'], 'alias'
+      assert_uniq "#{key}.commands", value['commands'], ['name', 'alias']
       assert_uniq "#{key}.flags", value['flags'], 'long'
       assert_uniq "#{key}.flags", value['flags'], 'short'
       assert_uniq "#{key}.args", value['args'], 'name'

--- a/lib/bashly/extensions/array.rb
+++ b/lib/bashly/extensions/array.rb
@@ -5,8 +5,8 @@ class Array
     map { |line| "#{indentation}#{line}" }
   end
 
-  def uniq?
-    self == uniq
+  def nonuniq
+    tally.select { |key, count| count > 1 }.keys
   end
 
 end

--- a/spec/approvals/validations/non_uniq_arg_names
+++ b/spec/approvals/validations/non_uniq_arg_names
@@ -1,1 +1,1 @@
-#<Bashly::ConfigurationError: root.args cannot have elements with similar name values>
+#<Bashly::ConfigurationError: root.args contains non-unique elements (file) in name>

--- a/spec/approvals/validations/non_uniq_command_aliases
+++ b/spec/approvals/validations/non_uniq_command_aliases
@@ -1,1 +1,1 @@
-#<Bashly::ConfigurationError: root.commands cannot have elements with similar alias values>
+#<Bashly::ConfigurationError: root.commands contains non-unique elements (c) in name or alias>

--- a/spec/approvals/validations/non_uniq_command_mix
+++ b/spec/approvals/validations/non_uniq_command_mix
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.commands contains non-unique elements (pull) in name or alias>

--- a/spec/approvals/validations/non_uniq_command_names
+++ b/spec/approvals/validations/non_uniq_command_names
@@ -1,1 +1,1 @@
-#<Bashly::ConfigurationError: root.commands cannot have elements with similar name values>
+#<Bashly::ConfigurationError: root.commands contains non-unique elements (download) in name or alias>

--- a/spec/approvals/validations/non_uniq_flags_longs
+++ b/spec/approvals/validations/non_uniq_flags_longs
@@ -1,1 +1,1 @@
-#<Bashly::ConfigurationError: root.flags cannot have elements with similar long values>
+#<Bashly::ConfigurationError: root.flags contains non-unique elements (--force) in long>

--- a/spec/approvals/validations/non_uniq_flags_shorts
+++ b/spec/approvals/validations/non_uniq_flags_shorts
@@ -1,1 +1,1 @@
-#<Bashly::ConfigurationError: root.flags cannot have elements with similar short values>
+#<Bashly::ConfigurationError: root.flags contains non-unique elements (-f) in short>

--- a/spec/bashly/extensions/array_spec.rb
+++ b/spec/bashly/extensions/array_spec.rb
@@ -13,4 +13,11 @@ describe Array do
       end
     end
   end
+
+  describe '#nonuniq' do
+    subject { %w[one it it two works three works] }
+    it "returns an array of non unique elements" do
+      expect(subject.nonuniq).to eq %w[it works]
+    end
+  end
 end

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -227,6 +227,15 @@
   - name: config
     alias: [c, conf]
 
+:non_uniq_command_mix:
+  name: invalid
+  help: alias of one command conflicts with name of another
+  commands:
+  - name: download
+    alias: pull
+  - name: pull
+    alias: [p, get]
+
 :non_uniq_flags_longs:
   name: invalid
   help: flags with the same long name


### PR DESCRIPTION
This PR improves the non-unique command validation by also ensuring that the name of one command does not conflict with an alias of another.