### PR TITLE
Update validator to alert when a default command has no args

### DIFF
--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -142,6 +142,10 @@ module Bashly
       assert_uniq "#{key}.flags", value['flags'], 'short'
       assert_uniq "#{key}.args", value['args'], 'name'
 
+      if value['default']
+        assert value['args'], "#{key}.default makes no sense without args"
+      end
+
       if value['catch_all'] and value['args']
         repeatable_arg = value['args'].select { |a| a['repeatable'] }.first&.dig 'name'
         refute repeatable_arg, "#{key}.catch_all makes no sense with repeatable arg (#{repeatable_arg})"

--- a/spec/approvals/validations/commands_default_without_args
+++ b/spec/approvals/validations/commands_default_without_args
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.commands[0].default makes no sense without args>

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -8,16 +8,16 @@
   name: invalid
   help: last nested arg does not have a name
   commands:
-    - name: level1
-      commands:
-        - name: level2a
-          args:
-            - name: ok
-            - name: alright
-        - name: level2b
-          args:          
-            - name: ok
-            - help: there is no name
+  - name: level1
+    commands:
+    - name: level2a
+      args:
+      - name: ok
+      - name: alright
+    - name: level2b
+      args:          
+      - name: ok
+      - help: there is no name
 
 :command_catch_all_type:
   name: invalid
@@ -101,6 +101,13 @@
   - name: sub
   flags:
   - long: --force
+
+:commands_default_without_args:
+  name: invalid
+  help: default command requires args
+  commands:
+  - name: sub
+    default: true
 
 :env_var:
   name: invalid
@@ -201,6 +208,8 @@
   name: invalid
   help: root cannot have default
   default: true
+  args:
+  - name: ok
 
 :root_expose:
   name: invalid


### PR DESCRIPTION
Before this PR, the following `bashly.yml` compiles properly, but the resulting CLI is not behaving as expected:

```yaml
name: cli
help: Sample application
version: 0.1.0

commands:
- name: download
  help: Download a file
  default: true

  args:
  - name: source
    help: URL to download from

  flags:
  - long: --force
    help: Overwrite existing files
```

Running `./cli --force` will not work, since a command set with `default: true` will only be executed when the first argument to the root CLI (normally, a command) is *not* a defined command, and will then assume it is an *argument* that needs to be passed on to the default command.

Therefore - at this point at least - a `default` command must have `args`.

This PR adds this validation.
