### PR TITLE
Add support for global command flags

### DIFF
--- a/examples/catch-all-advanced/README.md
+++ b/examples/catch-all-advanced/README.md
@@ -70,8 +70,8 @@ commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -90,7 +90,7 @@ cli download - Download a file
 Alias: d
 
 Usage:
-  cli download SOURCE [TARGET] [options] [AWS PARAMS...]
+  cli download SOURCE [TARGET] [OPTIONS] [AWS PARAMS...]
   cli download --help | -h
 
 Options:

--- a/examples/catch-all-stdin/README.md
+++ b/examples/catch-all-stdin/README.md
@@ -74,7 +74,7 @@ echo
 cli - Sample application
 
 Usage:
-  cli [options] [FILE...]
+  cli [OPTIONS] [FILE...]
   cli --help | -h
   cli --version | -v
 

--- a/examples/command-aliases/README.md
+++ b/examples/command-aliases/README.md
@@ -67,8 +67,8 @@ commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -85,8 +85,8 @@ Commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/examples/command-default/README.md
+++ b/examples/command-default/README.md
@@ -55,8 +55,8 @@ commands:
 ftp - Sample application that uses the default command option
 
 Usage:
-  ftp [command]
-  ftp [command] --help | -h
+  ftp COMMAND
+  ftp [COMMAND] --help | -h
   ftp --version | -v
 
 Commands:
@@ -73,8 +73,8 @@ Commands:
 ftp - Sample application that uses the default command option
 
 Usage:
-  ftp [command]
-  ftp [command] --help | -h
+  ftp COMMAND
+  ftp [COMMAND] --help | -h
   ftp --version | -v
 
 Commands:

--- a/examples/command-filenames/README.md
+++ b/examples/command-filenames/README.md
@@ -65,8 +65,8 @@ commands:
 cli - Demonstrate custom command filenames
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -83,8 +83,8 @@ Commands:
 cli - Demonstrate custom command filenames
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/examples/command-groups/README.md
+++ b/examples/command-groups/README.md
@@ -64,8 +64,8 @@ commands:
 ftp - Sample application with command grouping
 
 Usage:
-  ftp [command]
-  ftp [command] --help | -h
+  ftp COMMAND
+  ftp [COMMAND] --help | -h
   ftp --version | -v
 
 File Commands:
@@ -86,8 +86,8 @@ Login Commands:
 ftp - Sample application with command grouping
 
 Usage:
-  ftp [command]
-  ftp [command] --help | -h
+  ftp COMMAND
+  ftp [COMMAND] --help | -h
   ftp --version | -v
 
 File Commands:

--- a/examples/command-private/README.md
+++ b/examples/command-private/README.md
@@ -62,8 +62,8 @@ $cmd
 cli - Sample application with private commands
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -79,8 +79,8 @@ Commands:
 cli - Sample application with private commands
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/examples/commands-expose/README.md
+++ b/examples/commands-expose/README.md
@@ -74,8 +74,8 @@ commands:
 cli
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -98,8 +98,8 @@ Cluster Commands:
 cli
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/examples/commands-nested/README.md
+++ b/examples/commands-nested/README.md
@@ -74,8 +74,8 @@ commands:
 cli - Sample application with nested commands
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -92,8 +92,8 @@ Commands:
 cli - Sample application with nested commands
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -119,8 +119,8 @@ cli dir - Directory commands
 Alias: d
 
 Usage:
-  cli dir [command]
-  cli dir [command] --help | -h
+  cli dir COMMAND
+  cli dir [COMMAND] --help | -h
 
 Commands:
   list     Show files in the directory
@@ -138,13 +138,21 @@ cli file - File commands
 Alias: f
 
 Usage:
-  cli file [command]
-  cli file [command] --help | -h
+  cli file COMMAND
+  cli file [COMMAND] --help | -h
 
 Commands:
   show   Show file contents
   edit   Edit the file
 
+
+
+```
+
+### `$ ./cli dig`
+
+```shell
+invalid command: dig
 
 
 ```
@@ -157,8 +165,8 @@ cli dir - Directory commands
 Alias: d
 
 Usage:
-  cli dir [command]
-  cli dir [command] --help | -h
+  cli dir COMMAND
+  cli dir [COMMAND] --help | -h
 
 Commands:
   list     Show files in the directory
@@ -180,8 +188,8 @@ cli file - File commands
 Alias: f
 
 Usage:
-  cli file [command]
-  cli file [command] --help | -h
+  cli file COMMAND
+  cli file [COMMAND] --help | -h
 
 Commands:
   show   Show file contents
@@ -221,6 +229,14 @@ Arguments:
   PATH
     Directory path
 
+
+
+```
+
+### `$ ./cli dir lost -h`
+
+```shell
+invalid command: lost
 
 
 ```

--- a/examples/commands/README.md
+++ b/examples/commands/README.md
@@ -79,8 +79,8 @@ commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -97,8 +97,8 @@ Commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -136,7 +136,7 @@ cli download - Download a file
 Alias: d
 
 Usage:
-  cli download SOURCE [TARGET] [options]
+  cli download SOURCE [TARGET] [OPTIONS]
   cli download --help | -h
 
 Options:
@@ -169,7 +169,7 @@ Examples:
 
 ```shell
 missing required argument: SOURCE
-usage: cli download SOURCE [TARGET] [options]
+usage: cli download SOURCE [TARGET] [OPTIONS]
 
 
 ```
@@ -196,7 +196,7 @@ cli upload - Upload a file
 Alias: u
 
 Usage:
-  cli upload SOURCE [options]
+  cli upload SOURCE [OPTIONS]
   cli upload --help | -h
 
 Options:

--- a/examples/completions/README.md
+++ b/examples/completions/README.md
@@ -131,8 +131,8 @@ send_completions
 cli - Sample application with bash completions
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -150,8 +150,8 @@ Commands:
 cli - Sample application with bash completions
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -199,57 +199,76 @@ Options:
 # completely (https://github.com/dannyben/completely)
 # Modifying it manually is not recommended
 
+_cli_completions_filter() {
+  local words="$1"
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local result=()
+
+  if [[ "${cur:0:1}" == "-" ]]; then
+    echo "$words"
+  
+  else
+    for word in $words; do
+      [[ "${word:0:1}" != "-" ]] && result+=("$word")
+    done
+
+    echo "${result[*]}"
+
+  fi
+}
+
 _cli_completions() {
   local cur=${COMP_WORDS[COMP_CWORD]}
-  local compline="${COMP_WORDS[@]:1:$COMP_CWORD-1}"
+  local compwords=("${COMP_WORDS[@]:1:$COMP_CWORD-1}")
+  local compline="${compwords[*]}"
 
   case "$compline" in
     'download'*'--handler')
-      COMPREPLY=($(compgen -W "curl wget" -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_cli_completions_filter "curl wget")" -- "$cur" )
       ;;
 
     'upload'*'--user')
-      COMPREPLY=($(compgen -A user -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A user -- "$cur" )
       ;;
 
     'completions'*)
-      COMPREPLY=($(compgen -W "--help -h" -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_cli_completions_filter "--help -h")" -- "$cur" )
       ;;
 
     'd'*'--handler')
-      COMPREPLY=($(compgen -W "curl wget" -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_cli_completions_filter "curl wget")" -- "$cur" )
       ;;
 
     'upload'*'-u')
-      COMPREPLY=($(compgen -A user -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A user -- "$cur" )
       ;;
 
     'download'*)
-      COMPREPLY=($(compgen -A file -W "--force --handler --help -f -h" -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_cli_completions_filter "--force --handler --help -f -h")" -- "$cur" )
       ;;
 
     'u'*'--user')
-      COMPREPLY=($(compgen -A user -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A user -- "$cur" )
       ;;
 
     'upload'*)
-      COMPREPLY=($(compgen -A directory -A user -W "--help --password --user -h -p -u CHANGELOG.md README.md" -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A directory -A user -W "$(_cli_completions_filter "--help --password --user -h -p -u CHANGELOG.md README.md")" -- "$cur" )
       ;;
 
     'u'*'-u')
-      COMPREPLY=($(compgen -A user -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A user -- "$cur" )
       ;;
 
     'd'*)
-      COMPREPLY=($(compgen -A file -W "--force --handler --help -f -h" -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A file -W "$(_cli_completions_filter "--force --handler --help -f -h")" -- "$cur" )
       ;;
 
     'u'*)
-      COMPREPLY=($(compgen -A directory -A user -W "--help --password --user -h -p -u CHANGELOG.md README.md" -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -A directory -A user -W "$(_cli_completions_filter "--help --password --user -h -p -u CHANGELOG.md README.md")" -- "$cur" )
       ;;
 
     *)
-      COMPREPLY=($(compgen -W "--help --version -h -v completions d download u upload" -- "$cur"))
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_cli_completions_filter "--help --version -h -v completions d download u upload")" -- "$cur" )
       ;;
 
   esac

--- a/examples/config-ini/README.md
+++ b/examples/config-ini/README.md
@@ -121,8 +121,8 @@ echo "saved: ${args[key]} = ${args[value]}"
 configly - Sample application that uses the config functions
 
 Usage:
-  configly [command]
-  configly [command] --help | -h
+  configly COMMAND
+  configly [COMMAND] --help | -h
   configly --version | -v
 
 Commands:

--- a/examples/conflicts/README.md
+++ b/examples/conflicts/README.md
@@ -44,7 +44,7 @@ flags:
 download - Sample application to demonstrate the use of conflicting flags
 
 Usage:
-  download [options]
+  download [OPTIONS]
   download --help | -h
   download --version | -v
 

--- a/examples/custom-strings/README.md
+++ b/examples/custom-strings/README.md
@@ -70,7 +70,7 @@ missing_required_flag: "Yo! you forgot a flag: %{usage}"
 
 ```shell
 Boom! a required argument is missing: SOURCE
-usage: download SOURCE [options]
+usage: download SOURCE [OPTIONS]
 
 
 ```
@@ -82,7 +82,7 @@ download - Sample minimal application with custom strings
 
 == Usage ==
 
-  download SOURCE [options]
+  download SOURCE [OPTIONS]
   download --help | -h
   download --version | -v
 

--- a/examples/default-values/README.md
+++ b/examples/default-values/README.md
@@ -64,7 +64,7 @@ args:
 convert - Sample application using default arguments and flags
 
 Usage:
-  convert [SOURCE] [options]
+  convert [SOURCE] [OPTIONS]
   convert --help | -h
   convert --version | -v
 

--- a/examples/docker-like/README.md
+++ b/examples/docker-like/README.md
@@ -20,6 +20,11 @@ name: docker
 help: Docker example
 version: 0.1.0
 
+flags:
+- long: --debug
+  short: -d
+  help: Enable debug mode
+
 commands:
 - name: container
   alias: c*
@@ -48,6 +53,14 @@ commands:
   - name: ls
     alias: l
     help: Show all images
+
+- name: ps
+  help: List containers
+
+  flags:
+  - long: --all
+    short: -a
+    help: Show all containers
 ```
 
 
@@ -60,13 +73,14 @@ commands:
 docker - Docker example
 
 Usage:
-  docker [command]
-  docker [command] --help | -h
+  docker [OPTIONS] COMMAND
+  docker [COMMAND] --help | -h
   docker --version | -v
 
 Commands:
   container   Container commands
   image       Image commands
+  ps          List containers
 
 
 
@@ -78,13 +92,14 @@ Commands:
 docker - Docker example
 
 Usage:
-  docker [command]
-  docker [command] --help | -h
+  docker [OPTIONS] COMMAND
+  docker [COMMAND] --help | -h
   docker --version | -v
 
 Commands:
   container   Container commands
   image       Image commands
+  ps          List containers
 
 Options:
   --help, -h
@@ -92,6 +107,9 @@ Options:
 
   --version, -v
     Show version number
+
+  --debug, -d
+    Enable debug mode
 
 
 
@@ -105,8 +123,8 @@ docker container - Container commands
 Alias: c*
 
 Usage:
-  docker container [command]
-  docker container [command] --help | -h
+  docker container COMMAND
+  docker container [COMMAND] --help | -h
 
 Commands:
   run    Run a container
@@ -146,13 +164,14 @@ usage: docker container run IMAGE
 
 ```
 
-### `$ ./docker container run alpine`
+### `$ ./docker -d container run alpine`
 
 ```shell
 # this file is located in 'src/container_run_command.sh'
 # code for 'docker container run' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
+- ${args[--debug]} = 1
 - ${args[image]} = alpine
 
 
@@ -166,8 +185,8 @@ docker container - Container commands
 Alias: c*
 
 Usage:
-  docker container [command]
-  docker container [command] --help | -h
+  docker container COMMAND
+  docker container [COMMAND] --help | -h
 
 Commands:
   run    Run a container
@@ -185,8 +204,8 @@ docker image - Image commands
 Alias: i*
 
 Usage:
-  docker image [command]
-  docker image [command] --help | -h
+  docker image COMMAND
+  docker image [COMMAND] --help | -h
 
 Commands:
   ls   Show all images
@@ -213,6 +232,19 @@ args: none
 # code for 'docker image ls' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
 args: none
+
+
+```
+
+### `$ ./docker --debug ps --all`
+
+```shell
+# this file is located in 'src/ps_command.sh'
+# code for 'docker ps' goes here
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[--all]} = 1
+- ${args[--debug]} = 1
 
 
 ```

--- a/examples/docker-like/README.md
+++ b/examples/docker-like/README.md
@@ -3,6 +3,10 @@
 Demonstrates how to define deeply nested commands, similar to the docker cli
 (`docker container run`, `docker image ls`, etc.).
 
+In addition, this example shows the use of global flags, where flags defined 
+at the root level, become available to all nested commands, like the`--debug`
+flag in `docker --debug ps --all`.
+
 This example was generated with:
 
 ```bash

--- a/examples/docker-like/src/bashly.yml
+++ b/examples/docker-like/src/bashly.yml
@@ -2,6 +2,11 @@ name: docker
 help: Docker example
 version: 0.1.0
 
+flags:
+- long: --debug
+  short: -d
+  help: Enable debug mode
+
 commands:
 - name: container
   alias: c*
@@ -30,3 +35,11 @@ commands:
   - name: ls
     alias: l
     help: Show all images
+
+- name: ps
+  help: List containers
+
+  flags:
+  - long: --all
+    short: -a
+    help: Show all containers

--- a/examples/docker-like/src/ps_command.sh
+++ b/examples/docker-like/src/ps_command.sh
@@ -1,0 +1,4 @@
+echo "# this file is located in 'src/ps_command.sh'"
+echo "# code for 'docker ps' goes here"
+echo "# you can edit it freely and regenerate (it will not be overwritten)"
+inspect_args

--- a/examples/docker-like/test.sh
+++ b/examples/docker-like/test.sh
@@ -13,8 +13,9 @@ bashly generate
 ./docker container
 ./docker container run -h
 ./docker container run
-./docker container run alpine
+./docker -d container run alpine
 ./docker con
 ./docker image
 ./docker image ls
 ./docker i l
+./docker --debug ps --all

--- a/examples/environment-variables/README.md
+++ b/examples/environment-variables/README.md
@@ -75,8 +75,8 @@ echo "- MY_SECRET=${MY_SECRET:-}"
 cli - Sample application that requires environment variables
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -92,8 +92,8 @@ Commands:
 cli - Sample application that requires environment variables
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/examples/extensible-delegate/README.md
+++ b/examples/extensible-delegate/README.md
@@ -46,8 +46,8 @@ commands:
 mygit - Sample application that delegates unknown commands to a different executable
 
 Usage:
-  mygit [command]
-  mygit [command] --help | -h
+  mygit COMMAND
+  mygit [COMMAND] --help | -h
   mygit --version | -v
 
 Commands:

--- a/examples/extensible/README.md
+++ b/examples/extensible/README.md
@@ -67,8 +67,8 @@ echo "Received args: $@"
 cli - Sample application that can be externally extended
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/examples/git-like/README.md
+++ b/examples/git-like/README.md
@@ -50,8 +50,8 @@ commands:
 git - Git example
 
 Usage:
-  git [command]
-  git [command] --help | -h
+  git COMMAND
+  git [COMMAND] --help | -h
   git --version | -v
 
 Commands:
@@ -68,8 +68,8 @@ Commands:
 git - Git example
 
 Usage:
-  git [command]
-  git [command] --help | -h
+  git COMMAND
+  git [COMMAND] --help | -h
   git --version | -v
 
 Commands:
@@ -125,7 +125,7 @@ git commit - Commit changes
 Alias: c*
 
 Usage:
-  git commit [options]
+  git commit [OPTIONS]
   git commit --help | -h
 
 Options:

--- a/examples/help-command/README.md
+++ b/examples/help-command/README.md
@@ -119,8 +119,8 @@ fi
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -138,8 +138,8 @@ Commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -168,8 +168,8 @@ Environment Variables:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -200,7 +200,7 @@ cli download - Download a file
 Alias: d
 
 Usage:
-  cli download SOURCE [TARGET] [options]
+  cli download SOURCE [TARGET] [OPTIONS]
   cli download --help | -h
 
 Options:

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -43,7 +43,7 @@ examples:
 
 ```shell
 missing required argument: SOURCE
-usage: download SOURCE [TARGET] [options]
+usage: download SOURCE [TARGET] [OPTIONS]
 
 
 ```
@@ -54,7 +54,7 @@ usage: download SOURCE [TARGET] [options]
 download - Sample minimal application without commands
 
 Usage:
-  download SOURCE [TARGET] [options]
+  download SOURCE [TARGET] [OPTIONS]
   download --help | -h
   download --version | -v
 

--- a/examples/minus-v/README.md
+++ b/examples/minus-v/README.md
@@ -55,7 +55,7 @@ args: none
 cli - Example that replaces the default behavior of -v and -h
 
 Usage:
-  cli [options]
+  cli [OPTIONS]
   cli --help
   cli --version
 

--- a/examples/multiline/README.md
+++ b/examples/multiline/README.md
@@ -80,8 +80,8 @@ environment_variables:
 multi - Multiline test
 
 Usage:
-  multi [command]
-  multi [command] --help | -h
+  multi COMMAND
+  multi [COMMAND] --help | -h
   multi --version | -v
 
 Commands:
@@ -103,8 +103,8 @@ multi
   at the 80 character mark.
 
 Usage:
-  multi [command]
-  multi [command] --help | -h
+  multi COMMAND
+  multi [COMMAND] --help | -h
   multi --version | -v
 
 Commands:
@@ -159,7 +159,7 @@ multi multiline
   lines properly at the 80 character mark.
 
 Usage:
-  multi multiline [MY_ARG] [options]
+  multi multiline [MY_ARG] [OPTIONS]
   multi multiline --help | -h
 
 Options:

--- a/examples/repeatable-flag/README.md
+++ b/examples/repeatable-flag/README.md
@@ -79,7 +79,7 @@ inspect_args
 download - Sample application to demonstrate the use of repeatable flags
 
 Usage:
-  download [options]
+  download [OPTIONS]
   download --help | -h
   download --version
 

--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -89,8 +89,8 @@ strict: true
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/examples/split-config/README.md
+++ b/examples/split-config/README.md
@@ -93,8 +93,8 @@ inspect_args
 cli - Configuration splitting example
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -113,7 +113,7 @@ cli download - Download a file
 Alias: d
 
 Usage:
-  cli download SOURCE [TARGET] [options]
+  cli download SOURCE [TARGET] [OPTIONS]
   cli download --help | -h
 
 Options:
@@ -142,7 +142,7 @@ cli upload - Upload a file
 Alias: u
 
 Usage:
-  cli upload SOURCE [options]
+  cli upload SOURCE [OPTIONS]
   cli upload --help | -h
 
 Options:

--- a/examples/whitelist/README.md
+++ b/examples/whitelist/README.md
@@ -59,7 +59,7 @@ flags:
 
 ```shell
 missing required argument: REGION
-usage: login REGION [ENVIRONMENT] [options]
+usage: login REGION [ENVIRONMENT] [OPTIONS]
 
 
 ```
@@ -70,7 +70,7 @@ usage: login REGION [ENVIRONMENT] [options]
 login - Sample showing the use of arg and flag whitelist (allowed values)
 
 Usage:
-  login REGION [ENVIRONMENT] [options]
+  login REGION [ENVIRONMENT] [OPTIONS]
   login --help | -h
   login --version | -v
 

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -93,7 +93,7 @@ fi
 yaml - Sample application that uses the YAML functions
 
 Usage:
-  yaml FILENAME [VARIABLE] [options]
+  yaml FILENAME [VARIABLE] [OPTIONS]
   yaml --help | -h
   yaml --version | -v
 

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -112,7 +112,7 @@ module Bashly
       assert_hash key, value, Script::Command.option_keys
 
       refute value['commands'] && value['args'], "#{key} cannot have both commands and args"
-      refute value['commands'] && value['flags'], "#{key} cannot have both commands and flags"
+      # refute value['commands'] && value['flags'], "#{key} cannot have both commands and flags"
 
       assert_string "#{key}.name", value['name']
       assert_optional_string "#{key}.help", value['help']

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -112,7 +112,6 @@ module Bashly
       assert_hash key, value, Script::Command.option_keys
 
       refute value['commands'] && value['args'], "#{key} cannot have both commands and args"
-      # refute value['commands'] && value['flags'], "#{key} cannot have both commands and flags"
 
       assert_string "#{key}.name", value['name']
       assert_optional_string "#{key}.help", value['help']
@@ -149,6 +148,10 @@ module Bashly
       if value['catch_all'] and value['args']
         repeatable_arg = value['args'].select { |a| a['repeatable'] }.first&.dig 'name'
         refute repeatable_arg, "#{key}.catch_all makes no sense with repeatable arg (#{repeatable_arg})"
+      end
+
+      if value['catch_all']
+        refute value['commands'], "#{key}.catch_all makes no sense with commands"
       end
 
       if value['expose']

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -112,6 +112,7 @@ module Bashly
       assert_hash key, value, Script::Command.option_keys
 
       refute value['commands'] && value['args'], "#{key} cannot have both commands and args"
+      refute value['commands'] && value['catch_all'], "#{key} cannot have both commands and catch_all"
 
       assert_string "#{key}.name", value['name']
       assert_optional_string "#{key}.help", value['help']
@@ -148,10 +149,6 @@ module Bashly
       if value['catch_all'] and value['args']
         repeatable_arg = value['args'].select { |a| a['repeatable'] }.first&.dig 'name'
         refute repeatable_arg, "#{key}.catch_all makes no sense with repeatable arg (#{repeatable_arg})"
-      end
-
-      if value['catch_all']
-        refute value['commands'], "#{key}.catch_all makes no sense with commands"
       end
 
       if value['expose']

--- a/lib/bashly/script/command.rb
+++ b/lib/bashly/script/command.rb
@@ -177,6 +177,12 @@ module Bashly
         parents.any? ? (parents + [name]).join(' ') : name
       end
 
+      # Returns true if this command's flags should be considered as gloal
+      # flags, and cascade to subcommands
+      def global_flags?
+        flags.any? and commands.any?
+      end
+
       # Returns the string for the group caption
       def group_string
         if group
@@ -239,11 +245,12 @@ module Bashly
       # Returns a constructed string suitable for Usage pattern
       def usage_string
         result = [full_name]
-        result << "[command]" if commands.any?
+        result << "[OPTIONS]" if global_flags?
+        result << "COMMAND" if commands.any?
         args.each do |arg|
           result << arg.usage_string
         end
-        result << "[options]" unless flags.empty?
+        result << "[OPTIONS]" unless flags.empty? || global_flags?
         result << catch_all.usage_string if catch_all.enabled?
         result.join " "
       end

--- a/lib/bashly/views/command/fixed_flags_filter.gtx
+++ b/lib/bashly/views/command/fixed_flags_filter.gtx
@@ -16,5 +16,12 @@ end
 >   exit
 >   ;;
 > 
+
+if global_flags?
+  flags.each do |flag|
+    = flag.render(:case)
+  end
+end
+
 > esac
 >

--- a/lib/bashly/views/command/parse_requirements_while.gtx
+++ b/lib/bashly/views/command/parse_requirements_while.gtx
@@ -4,8 +4,10 @@
 >   key="$1"
 >   case "$key" in
 
-flags.each do |flag|
-  = flag.render(:case).indent 2
+unless global_flags?
+  flags.each do |flag|
+    = flag.render(:case).indent 2
+  end
 end
 
 >

--- a/lib/bashly/views/command/usage.gtx
+++ b/lib/bashly/views/command/usage.gtx
@@ -29,7 +29,7 @@ end
 >   printf "  {{ usage_string }}\n"
 
 if commands.any?
-  >   printf "  {{ full_name }} [command] --help{{ " | -h" unless short_flag_exist? "-h" }}\n"
+  >   printf "  {{ full_name }} [COMMAND] --help{{ " | -h" unless short_flag_exist? "-h" }}\n"
 else
   >   printf "  {{ full_name }} --help{{ " | -h" unless short_flag_exist? "-h" }}\n"
 end

--- a/spec/approvals/examples/catch-all-advanced
+++ b/spec/approvals/examples/catch-all-advanced
@@ -9,8 +9,8 @@ run ./cli --help to test your bash script
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -23,7 +23,7 @@ cli download - Download a file
 Alias: d
 
 Usage:
-  cli download SOURCE [TARGET] [options] [AWS PARAMS...]
+  cli download SOURCE [TARGET] [OPTIONS] [AWS PARAMS...]
   cli download --help | -h
 
 Options:

--- a/spec/approvals/examples/catch-all-stdin
+++ b/spec/approvals/examples/catch-all-stdin
@@ -6,7 +6,7 @@ run ./cli --help to test your bash script
 cli - Sample application
 
 Usage:
-  cli [options] [FILE...]
+  cli [OPTIONS] [FILE...]
   cli --help | -h
   cli --version | -v
 

--- a/spec/approvals/examples/command-aliases
+++ b/spec/approvals/examples/command-aliases
@@ -9,8 +9,8 @@ run ./cli --help to test your bash script
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -21,8 +21,8 @@ Commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/examples/command-default
+++ b/spec/approvals/examples/command-default
@@ -9,8 +9,8 @@ run ./ftp --help to test your bash script
 ftp - Sample application that uses the default command option
 
 Usage:
-  ftp [command]
-  ftp [command] --help | -h
+  ftp COMMAND
+  ftp [COMMAND] --help | -h
   ftp --version | -v
 
 Commands:
@@ -21,8 +21,8 @@ Commands:
 ftp - Sample application that uses the default command option
 
 Usage:
-  ftp [command]
-  ftp [command] --help | -h
+  ftp COMMAND
+  ftp [COMMAND] --help | -h
   ftp --version | -v
 
 Commands:

--- a/spec/approvals/examples/command-filenames
+++ b/spec/approvals/examples/command-filenames
@@ -11,8 +11,8 @@ run ./cli --help to test your bash script
 cli - Demonstrate custom command filenames
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -23,8 +23,8 @@ Commands:
 cli - Demonstrate custom command filenames
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/examples/command-groups
+++ b/spec/approvals/examples/command-groups
@@ -11,8 +11,8 @@ run ./ftp --help to test your bash script
 ftp - Sample application with command grouping
 
 Usage:
-  ftp [command]
-  ftp [command] --help | -h
+  ftp COMMAND
+  ftp [COMMAND] --help | -h
   ftp --version | -v
 
 File Commands:
@@ -27,8 +27,8 @@ Login Commands:
 ftp - Sample application with command grouping
 
 Usage:
-  ftp [command]
-  ftp [command] --help | -h
+  ftp COMMAND
+  ftp [COMMAND] --help | -h
   ftp --version | -v
 
 File Commands:

--- a/spec/approvals/examples/command-private
+++ b/spec/approvals/examples/command-private
@@ -10,8 +10,8 @@ run ./cli --help to test your bash script
 cli - Sample application with private commands
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -21,8 +21,8 @@ Commands:
 cli - Sample application with private commands
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/examples/commands
+++ b/spec/approvals/examples/commands
@@ -9,8 +9,8 @@ run ./cli --help to test your bash script
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -21,8 +21,8 @@ Commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -48,7 +48,7 @@ cli download - Download a file
 Alias: d
 
 Usage:
-  cli download SOURCE [TARGET] [options]
+  cli download SOURCE [TARGET] [OPTIONS]
   cli download --help | -h
 
 Options:
@@ -75,7 +75,7 @@ Examples:
 
 + ./cli download
 missing required argument: SOURCE
-usage: cli download SOURCE [TARGET] [options]
+usage: cli download SOURCE [TARGET] [OPTIONS]
 + ./cli download sourcefile targetfile -f
 # this file is located in 'src/download_command.sh'
 # code for 'cli download' goes here
@@ -90,7 +90,7 @@ cli upload - Upload a file
 Alias: u
 
 Usage:
-  cli upload SOURCE [options]
+  cli upload SOURCE [OPTIONS]
   cli upload --help | -h
 
 Options:

--- a/spec/approvals/examples/commands-expose
+++ b/spec/approvals/examples/commands-expose
@@ -14,8 +14,8 @@ run ./cli --help to test your bash script
 cli
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -32,8 +32,8 @@ Cluster Commands:
 cli
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/examples/commands-nested
+++ b/spec/approvals/examples/commands-nested
@@ -11,8 +11,8 @@ run ./cli --help to test your bash script
 cli - Sample application with nested commands
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -23,8 +23,8 @@ Commands:
 cli - Sample application with nested commands
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -44,8 +44,8 @@ cli dir - Directory commands
 Alias: d
 
 Usage:
-  cli dir [command]
-  cli dir [command] --help | -h
+  cli dir COMMAND
+  cli dir [COMMAND] --help | -h
 
 Commands:
   list     Show files in the directory
@@ -57,8 +57,8 @@ cli file - File commands
 Alias: f
 
 Usage:
-  cli file [command]
-  cli file [command] --help | -h
+  cli file COMMAND
+  cli file [COMMAND] --help | -h
 
 Commands:
   show   Show file contents
@@ -72,8 +72,8 @@ cli dir - Directory commands
 Alias: d
 
 Usage:
-  cli dir [command]
-  cli dir [command] --help | -h
+  cli dir COMMAND
+  cli dir [COMMAND] --help | -h
 
 Commands:
   list     Show files in the directory
@@ -89,8 +89,8 @@ cli file - File commands
 Alias: f
 
 Usage:
-  cli file [command]
-  cli file [command] --help | -h
+  cli file COMMAND
+  cli file [COMMAND] --help | -h
 
 Commands:
   show   Show file contents

--- a/spec/approvals/examples/completions
+++ b/spec/approvals/examples/completions
@@ -19,8 +19,8 @@ run ./cli --help to test your bash script
 cli - Sample application with bash completions
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -32,8 +32,8 @@ Commands:
 cli - Sample application with bash completions
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/examples/config-ini
+++ b/spec/approvals/examples/config-ini
@@ -10,8 +10,8 @@ run ./configly --help to test your bash script
 configly - Sample application that uses the config functions
 
 Usage:
-  configly [command]
-  configly [command] --help | -h
+  configly COMMAND
+  configly [COMMAND] --help | -h
   configly --version | -v
 
 Commands:

--- a/spec/approvals/examples/conflicts
+++ b/spec/approvals/examples/conflicts
@@ -8,7 +8,7 @@ run ./download --help to test your bash script
 download - Sample application to demonstrate the use of conflicting flags
 
 Usage:
-  download [options]
+  download [OPTIONS]
   download --help | -h
   download --version | -v
 

--- a/spec/approvals/examples/custom-strings
+++ b/spec/approvals/examples/custom-strings
@@ -6,13 +6,13 @@ created ./download
 run ./download --help to test your bash script
 + ./download
 Boom! a required argument is missing: SOURCE
-usage: download SOURCE [options]
+usage: download SOURCE [OPTIONS]
 + ./download -h
 download - Sample minimal application with custom strings
 
 == Usage ==
 
-  download SOURCE [options]
+  download SOURCE [OPTIONS]
   download --help | -h
   download --version | -v
 

--- a/spec/approvals/examples/default-values
+++ b/spec/approvals/examples/default-values
@@ -14,7 +14,7 @@ args:
 convert - Sample application using default arguments and flags
 
 Usage:
-  convert [SOURCE] [options]
+  convert [SOURCE] [OPTIONS]
   convert --help | -h
   convert --version | -v
 

--- a/spec/approvals/examples/docker-like
+++ b/spec/approvals/examples/docker-like
@@ -4,31 +4,34 @@ created src/initialize.sh
 created src/container_run_command.sh
 created src/container_stop_command.sh
 created src/image_ls_command.sh
+created src/ps_command.sh
 created ./docker
 run ./docker --help to test your bash script
 + ./docker
 docker - Docker example
 
 Usage:
-  docker COMMAND
+  docker [OPTIONS] COMMAND
   docker [COMMAND] --help | -h
   docker --version | -v
 
 Commands:
   container   Container commands
   image       Image commands
+  ps          List containers
 
 + ./docker -h
 docker - Docker example
 
 Usage:
-  docker COMMAND
+  docker [OPTIONS] COMMAND
   docker [COMMAND] --help | -h
   docker --version | -v
 
 Commands:
   container   Container commands
   image       Image commands
+  ps          List containers
 
 Options:
   --help, -h
@@ -36,6 +39,9 @@ Options:
 
   --version, -v
     Show version number
+
+  --debug, -d
+    Enable debug mode
 
 + ./docker container
 docker container - Container commands
@@ -68,11 +74,12 @@ Arguments:
 + ./docker container run
 missing required argument: IMAGE
 usage: docker container run IMAGE
-+ ./docker container run alpine
++ ./docker -d container run alpine
 # this file is located in 'src/container_run_command.sh'
 # code for 'docker container run' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
+- ${args[--debug]} = 1
 - ${args[image]} = alpine
 + ./docker con
 docker container - Container commands
@@ -109,3 +116,10 @@ args: none
 # code for 'docker image ls' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
 args: none
++ ./docker --debug ps --all
+# this file is located in 'src/ps_command.sh'
+# code for 'docker ps' goes here
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[--all]} = 1
+- ${args[--debug]} = 1

--- a/spec/approvals/examples/docker-like
+++ b/spec/approvals/examples/docker-like
@@ -10,8 +10,8 @@ run ./docker --help to test your bash script
 docker - Docker example
 
 Usage:
-  docker [command]
-  docker [command] --help | -h
+  docker COMMAND
+  docker [COMMAND] --help | -h
   docker --version | -v
 
 Commands:
@@ -22,8 +22,8 @@ Commands:
 docker - Docker example
 
 Usage:
-  docker [command]
-  docker [command] --help | -h
+  docker COMMAND
+  docker [COMMAND] --help | -h
   docker --version | -v
 
 Commands:
@@ -43,8 +43,8 @@ docker container - Container commands
 Alias: c*
 
 Usage:
-  docker container [command]
-  docker container [command] --help | -h
+  docker container COMMAND
+  docker container [COMMAND] --help | -h
 
 Commands:
   run    Run a container
@@ -80,8 +80,8 @@ docker container - Container commands
 Alias: c*
 
 Usage:
-  docker container [command]
-  docker container [command] --help | -h
+  docker container COMMAND
+  docker container [COMMAND] --help | -h
 
 Commands:
   run    Run a container
@@ -93,8 +93,8 @@ docker image - Image commands
 Alias: i*
 
 Usage:
-  docker image [command]
-  docker image [command] --help | -h
+  docker image COMMAND
+  docker image [COMMAND] --help | -h
 
 Commands:
   ls   Show all images

--- a/spec/approvals/examples/environment-variables
+++ b/spec/approvals/examples/environment-variables
@@ -8,8 +8,8 @@ run ./cli --help to test your bash script
 cli - Sample application that requires environment variables
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -19,8 +19,8 @@ Commands:
 cli - Sample application that requires environment variables
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/examples/extensible
+++ b/spec/approvals/examples/extensible
@@ -9,8 +9,8 @@ run ./cli --help to test your bash script
 cli - Sample application that can be externally extended
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/examples/extensible-delegate
+++ b/spec/approvals/examples/extensible-delegate
@@ -9,8 +9,8 @@ run ./mygit --help to test your bash script
 mygit - Sample application that delegates unknown commands to a different executable
 
 Usage:
-  mygit [command]
-  mygit [command] --help | -h
+  mygit COMMAND
+  mygit [COMMAND] --help | -h
   mygit --version | -v
 
 Commands:

--- a/spec/approvals/examples/git-like
+++ b/spec/approvals/examples/git-like
@@ -9,8 +9,8 @@ run ./git --help to test your bash script
 git - Git example
 
 Usage:
-  git [command]
-  git [command] --help | -h
+  git COMMAND
+  git [COMMAND] --help | -h
   git --version | -v
 
 Commands:
@@ -21,8 +21,8 @@ Commands:
 git - Git example
 
 Usage:
-  git [command]
-  git [command] --help | -h
+  git COMMAND
+  git [COMMAND] --help | -h
   git --version | -v
 
 Commands:
@@ -60,7 +60,7 @@ git commit - Commit changes
 Alias: c*
 
 Usage:
-  git commit [options]
+  git commit [OPTIONS]
   git commit --help | -h
 
 Options:

--- a/spec/approvals/examples/help-command
+++ b/spec/approvals/examples/help-command
@@ -10,8 +10,8 @@ run ./cli --help to test your bash script
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -23,8 +23,8 @@ Commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -47,8 +47,8 @@ Environment Variables:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -73,7 +73,7 @@ cli download - Download a file
 Alias: d
 
 Usage:
-  cli download SOURCE [TARGET] [options]
+  cli download SOURCE [TARGET] [OPTIONS]
   cli download --help | -h
 
 Options:

--- a/spec/approvals/examples/minimal
+++ b/spec/approvals/examples/minimal
@@ -6,12 +6,12 @@ created ./download
 run ./download --help to test your bash script
 + ./download
 missing required argument: SOURCE
-usage: download SOURCE [TARGET] [options]
+usage: download SOURCE [TARGET] [OPTIONS]
 + ./download -h
 download - Sample minimal application without commands
 
 Usage:
-  download SOURCE [TARGET] [options]
+  download SOURCE [TARGET] [OPTIONS]
   download --help | -h
   download --version | -v
 

--- a/spec/approvals/examples/minus-v
+++ b/spec/approvals/examples/minus-v
@@ -12,7 +12,7 @@ args: none
 cli - Example that replaces the default behavior of -v and -h
 
 Usage:
-  cli [options]
+  cli [OPTIONS]
   cli --help
   cli --version
 

--- a/spec/approvals/examples/multiline
+++ b/spec/approvals/examples/multiline
@@ -9,8 +9,8 @@ run ./multi --help to test your bash script
 multi - Multiline test
 
 Usage:
-  multi [command]
-  multi [command] --help | -h
+  multi COMMAND
+  multi [COMMAND] --help | -h
   multi --version | -v
 
 Commands:
@@ -26,8 +26,8 @@ multi
   at the 80 character mark.
 
 Usage:
-  multi [command]
-  multi [command] --help | -h
+  multi COMMAND
+  multi [COMMAND] --help | -h
   multi --version | -v
 
 Commands:
@@ -70,7 +70,7 @@ multi multiline
   lines properly at the 80 character mark.
 
 Usage:
-  multi multiline [MY_ARG] [options]
+  multi multiline [MY_ARG] [OPTIONS]
   multi multiline --help | -h
 
 Options:

--- a/spec/approvals/examples/repeatable-flag
+++ b/spec/approvals/examples/repeatable-flag
@@ -8,7 +8,7 @@ run ./download --help to test your bash script
 download - Sample application to demonstrate the use of repeatable flags
 
 Usage:
-  download [options]
+  download [OPTIONS]
   download --help | -h
   download --version
 

--- a/spec/approvals/examples/settings
+++ b/spec/approvals/examples/settings
@@ -9,8 +9,8 @@ run out/cli --help to test your bash script
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/examples/split-config
+++ b/spec/approvals/examples/split-config
@@ -9,8 +9,8 @@ run ./cli --help to test your bash script
 cli - Configuration splitting example
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -23,7 +23,7 @@ cli download - Download a file
 Alias: d
 
 Usage:
-  cli download SOURCE [TARGET] [options]
+  cli download SOURCE [TARGET] [OPTIONS]
   cli download --help | -h
 
 Options:
@@ -46,7 +46,7 @@ cli upload - Upload a file
 Alias: u
 
 Usage:
-  cli upload SOURCE [options]
+  cli upload SOURCE [OPTIONS]
   cli upload --help | -h
 
 Options:

--- a/spec/approvals/examples/whitelist
+++ b/spec/approvals/examples/whitelist
@@ -6,12 +6,12 @@ created ./login
 run ./login --help to test your bash script
 + ./login
 missing required argument: REGION
-usage: login REGION [ENVIRONMENT] [options]
+usage: login REGION [ENVIRONMENT] [OPTIONS]
 + ./login -h
 login - Sample showing the use of arg and flag whitelist (allowed values)
 
 Usage:
-  login REGION [ENVIRONMENT] [options]
+  login REGION [ENVIRONMENT] [OPTIONS]
   login --help | -h
   login --version | -v
 

--- a/spec/approvals/examples/yaml
+++ b/spec/approvals/examples/yaml
@@ -8,7 +8,7 @@ run ./yaml --help to test your bash script
 yaml - Sample application that uses the YAML functions
 
 Usage:
-  yaml FILENAME [VARIABLE] [options]
+  yaml FILENAME [VARIABLE] [OPTIONS]
   yaml --help | -h
   yaml --version | -v
 

--- a/spec/approvals/fixtures/bash-3-syntax
+++ b/spec/approvals/fixtures/bash-3-syntax
@@ -6,8 +6,8 @@ run ./cli --help to test your bash script
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/fixtures/environment-variables-initialize
+++ b/spec/approvals/fixtures/environment-variables-initialize
@@ -25,8 +25,8 @@ PASS: NESTED_VAR is empty
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/fixtures/exit-codes
+++ b/spec/approvals/fixtures/exit-codes
@@ -11,8 +11,8 @@ missing required environment variable: API_KEY
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:
@@ -24,8 +24,8 @@ Commands:
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/fixtures/required-args-order
+++ b/spec/approvals/fixtures/required-args-order
@@ -6,10 +6,10 @@ created ./download
 run ./download --help to test your bash script
 + ./download
 missing required argument: PROTOCOL
-usage: download PROTOCOL PORT [BODY] [options]
+usage: download PROTOCOL PORT [BODY] [OPTIONS]
 + ./download http
 missing required argument: PORT
-usage: download PROTOCOL PORT [BODY] [options]
+usage: download PROTOCOL PORT [BODY] [OPTIONS]
 + ./download http 3000
 missing required flag: --method NAME
 + ./download http 3000 --method GET

--- a/spec/approvals/fixtures/version-in-subcommands
+++ b/spec/approvals/fixtures/version-in-subcommands
@@ -10,8 +10,8 @@ run ./cli --help to test your bash script
 cli - Sample application
 
 Usage:
-  cli [command]
-  cli [command] --help | -h
+  cli COMMAND
+  cli [COMMAND] --help | -h
   cli --version | -v
 
 Commands:

--- a/spec/approvals/validations/command_catch_all_commands
+++ b/spec/approvals/validations/command_catch_all_commands
@@ -1,1 +1,1 @@
-#<Bashly::ConfigurationError: root.catch_all makes no sense with commands>
+#<Bashly::ConfigurationError: root cannot have both commands and catch_all>

--- a/spec/approvals/validations/command_catch_all_commands
+++ b/spec/approvals/validations/command_catch_all_commands
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.catch_all makes no sense with commands>

--- a/spec/bashly/script/command_spec.rb
+++ b/spec/bashly/script/command_spec.rb
@@ -140,7 +140,7 @@ describe Script::Command do
     it "returns a Command object of the first default command" do
       expect(subject.default_command).to be_a Script::Command
       expect(subject.default_command.name).to eq 'get'
-    end    
+    end
   end
 
   describe '#default_flags' do
@@ -234,6 +234,32 @@ describe Script::Command do
 
       it "returns the a string with all parents joined" do
         expect(subject.full_name).to eq "git status"
+      end
+    end
+  end
+
+  describe '#global_flags?' do
+    context "when a command has flags and commands" do
+      let(:fixture) { :mode_global_flags }
+
+      it "returns true" do
+        expect(subject.global_flags?).to be_truthy
+      end
+    end
+
+    context "when a command has flags but no commands" do
+      let(:fixture) { :mode_flags }
+
+      it "returns false" do
+        expect(subject.global_flags?).to be_falsy
+      end
+    end
+
+    context "when a command has commands but no flags" do
+      let(:fixture) { :mode_commands }
+
+      it "returns false" do
+        expect(subject.global_flags?).to be_falsy
       end
     end
   end
@@ -352,42 +378,118 @@ describe Script::Command do
     end
   end
 
-  describe '#usage_string' do
-    context "when no args and no commands are defined" do
-      let(:fixture) { :git_status }
+  describe '#mode' do
+    context "when flags and commands are defined" do
+      let(:fixture) { :mode_global_flags }
 
-      it "returns a string suitable to be used as a usage pattern" do
-        expect(subject.usage_string).to eq "git status"
+      it "returns :global_flags" do
+        expect(subject.mode).to eq :global_flags
       end
     end
 
-    context "when flags are defined" do
-      let(:fixture) { :flags_only_command }
+    context "when only commands are defined" do
+      let(:fixture) { :mode_commands }
 
-      it "adds [OPTIONS] to the usage string" do
-        expect(subject.usage_string).to eq "git status [OPTIONS]"
-      end      
+      it "returns :commands" do
+        expect(subject.mode).to eq :commands
+      end
     end
 
-    context "when args are defined" do
-      it "includes them in the usage string" do
-        expect(subject.usage_string).to eq "get SOURCE [TARGET] [OPTIONS]"
-      end      
+    context "when args and flags are defined" do
+      let(:fixture) { :mode_args_and_flags }
+
+      it "returns :args_and_flags" do
+        expect(subject.mode).to eq :args_and_flags
+      end
     end
 
-    context "when commands are defined" do
-      let(:fixture) { :docker }
+    context "when only args are defined" do
+      let(:fixture) { :mode_args }
 
-      it "includes [command] in the usage string" do
-        expect(subject.usage_string).to eq "docker COMMAND"
-      end      
+      it "returns :args" do
+        expect(subject.mode).to eq :args
+      end
     end
 
-    context "when catch_all is enabled" do
-      let(:fixture) { :catch_all }
+    context "when only flags are defined" do
+      let(:fixture) { :mode_flags }
 
-      it "includes the catch_all usage string" do
-        expect(subject.usage_string).to eq "get [...]"
+      it "returns :flags" do
+        expect(subject.mode).to eq :flags
+      end
+    end
+
+    context "when nothing is defined" do
+      let(:fixture) { :mode_empty }
+
+      it "returns :empty" do
+        expect(subject.mode).to eq :empty
+      end
+    end
+  end
+
+  describe '#usage_string' do
+    context "when flags and commands are defined" do
+      let(:fixture) { :mode_global_flags }
+
+      it "returns the correct string" do
+        expect(subject.usage_string).to eq "get [OPTIONS] COMMAND"
+      end
+    end
+
+    context "when only commands are defined" do
+      let(:fixture) { :mode_commands }
+
+      it "returns the correct string" do
+        expect(subject.usage_string).to eq "get COMMAND"
+      end
+    end
+
+    context "when args and flags are defined" do
+      let(:fixture) { :mode_args_and_flags }
+
+      it "returns the correct string" do
+        expect(subject.usage_string).to eq "get SOURCE [TARGET] [OPTIONS] [PARAMS...]"
+      end
+    end
+
+    context "when only args are defined" do
+      let(:fixture) { :mode_args }
+
+      it "returns the correct string" do
+        expect(subject.usage_string).to eq "get SOURCE [TARGET] [PARAMS...]"
+      end
+    end
+
+    context "when only flags are defined" do
+      let(:fixture) { :mode_flags }
+
+      it "returns the correct string" do
+        expect(subject.usage_string).to eq "get [OPTIONS] [PARAMS...]"
+      end
+
+      context "when it has a parent" do
+        let(:fixture) { :flags_only_command }
+
+        it "returns the correct string" do
+          expect(subject.usage_string).to eq "git status [OPTIONS]"
+        end
+      end
+    end
+
+    context "when nothing is defined" do
+      let(:fixture) { :mode_empty }
+
+      it "returns the correct string" do
+        expect(subject.usage_string).to eq "get [PARAMS...]"
+      end
+
+      context "when it has a parent" do
+        let(:fixture) { :git_status }
+
+        it "returns the correct string" do
+          expect(subject.usage_string).to eq "git status"
+        end
       end
     end
   end

--- a/spec/bashly/script/command_spec.rb
+++ b/spec/bashly/script/command_spec.rb
@@ -364,14 +364,14 @@ describe Script::Command do
     context "when flags are defined" do
       let(:fixture) { :flags_only_command }
 
-      it "adds [options] to the usate string" do
-        expect(subject.usage_string).to eq "git status [options]"
+      it "adds [OPTIONS] to the usage string" do
+        expect(subject.usage_string).to eq "git status [OPTIONS]"
       end      
     end
 
     context "when args are defined" do
       it "includes them in the usage string" do
-        expect(subject.usage_string).to eq "get SOURCE [TARGET] [options]"
+        expect(subject.usage_string).to eq "get SOURCE [TARGET] [OPTIONS]"
       end      
     end
 
@@ -379,7 +379,7 @@ describe Script::Command do
       let(:fixture) { :docker }
 
       it "includes [command] in the usage string" do
-        expect(subject.usage_string).to eq "docker [command]"
+        expect(subject.usage_string).to eq "docker COMMAND"
       end      
     end
 

--- a/spec/fixtures/script/commands.yml
+++ b/spec/fixtures/script/commands.yml
@@ -217,6 +217,70 @@
   name: get
   help: get something from somewhere
 
+:mode_global_flags:
+  name: get
+  help: get something from somewhere
+
+  flags:
+  - long: --force
+  - long: --verbose
+
+  commands:
+  - name: download
+    flags:
+    - long: --http
+  - name: upload
+
+:mode_commands:
+  name: get
+  help: get something from somewhere
+
+  commands:
+  - name: download
+    flags:
+    - long: --http
+  - name: upload
+
+:mode_args_and_flags:
+  name: get
+  help: get something from somewhere
+  catch_all: params
+
+  args:
+  - name: source
+    required: true
+  - name: target
+
+  flags:
+  - long: --force
+    required: true
+  - long: --verbose
+
+:mode_args:
+  name: get
+  help: get something from somewhere
+  catch_all: params
+
+  args:
+  - name: source
+    required: true
+  - name: target
+
+:mode_flags:
+  name: get
+  help: get something from somewhere
+  catch_all: params
+
+  flags:
+  - long: --force
+    required: true
+  - long: --verbose
+
+:mode_empty:
+  name: get
+  help: get something from somewhere
+  catch_all: params
+
 :nested_aliases:
   name: cli
   commands:

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -94,13 +94,13 @@
   args:
   - name: source
 
-:commands_and_flags:
-  name: invalid
-  help: there are both commands and flags
-  commands:
-  - name: sub
-  flags:
-  - long: --force
+# :commands_and_flags:
+#   name: invalid
+#   help: there are both commands and flags
+#   commands:
+#   - name: sub
+#   flags:
+#   - long: --force
 
 :commands_default_without_args:
   name: invalid

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -102,14 +102,6 @@
   args:
   - name: source
 
-# :commands_and_flags:
-#   name: invalid
-#   help: there are both commands and flags
-#   commands:
-#   - name: sub
-#   flags:
-#   - long: --force
-
 :commands_default_without_args:
   name: invalid
   help: default command requires args

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -36,6 +36,14 @@
     help: catch_all.required should be boolean
     required: 1
 
+:command_catch_all_commands:
+  name: invalid
+  catch_all:
+    label: params
+    help: catch_all makes no sense with commands
+  commands:
+  - name: config
+
 :command_expose_invalid_type:
   name: invalid
   help: expose should be boolean or 'always'


### PR DESCRIPTION
This PR allows creating CLIs that respond to patterns like this:

```bash
$ docker --debug ps -a
#        /\ --debug is a global flag that cascades downstream to all subcommands
```

by simply defining the usual `flags` in a command that also has `commands`:

```yaml
name: docker
help: Docker wannabe
version: 0.1.0

flags:
- long: --debug
  short: -d
  help: Enable debug mode

commands:
- name: ps
  help: List containers

  flags:
  - long: --all
    short: -a
    help: Show all containers
```

### Notes:

- Before this PR, having both `flags` and `commands` was not allowed (blocked by the validator). This PR obviously removes this limitation.
- This PR adds a new validation rule: `catch_all` is no longer allowed when `commands` are present (it was never supported, just never validated before). Of course, `catch_all` can still be defined on any subcommand or on a root command that has no commands.
- The `Command#usage_string` method was heavily refactored since it started to accumulate cognitive complexity.
- The usage string output was slightly changed from something like `cli [options] [command]` to `cli [OPTIONS] [COMMAND]` - this is the primary reason for all the changes to the approvals and examples in this PR.

Closes #258