### PR TITLE
Refactor settings (internal)

### DIFF
--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -1,18 +1,20 @@
 module Bashly
   class Settings
     class << self
+      include AssetHelper
+
       attr_writer :source_dir, :target_dir, :lib_dir, :strict, :tab_indent
 
       def source_dir
-        @source_dir ||= get :source_dir, 'src'
+        @source_dir ||= get :source_dir
       end
 
       def target_dir
-        @target_dir ||= get :target_dir, '.'
+        @target_dir ||= get :target_dir
       end
 
       def lib_dir
-        @lib_dir ||= get :lib_dir, 'lib'
+        @lib_dir ||= get :lib_dir
       end
 
       def strict
@@ -24,7 +26,7 @@ module Bashly
       end
 
       def env
-        @env ||= get(:env, :development)&.to_sym
+        @env ||= get(:env)&.to_sym
       end
 
       def env=(value)
@@ -41,14 +43,33 @@ module Bashly
 
     private
 
-      def get(key, default = nil)
-        ENV["BASHLY_#{key.upcase}"] || user_settings[key.to_s] || default
+      def get(key)
+        case env_value key
+        when nil                 then config[key.to_s]
+        when "0", "false", "no"  then false
+        when "1", "true", "yes"  then true
+        else                     env_value key
+        end
+      end
+
+      def env_value(key)
+        ENV["BASHLY_#{key.upcase}"]
+      end
+
+      def config
+        @config ||= defsult_settings.merge user_settings
       end
 
       def user_settings
-        @user_settings ||= begin
-          File.exist?('settings.yml') ? Config.new('settings.yml') : {}
-        end
+        @user_settings ||= File.exist?('settings.yml') ? Config.new('settings.yml') : {}
+      end
+
+      def defsult_settings
+        @defsult_settings ||= Config.new(default_settings_path)
+      end
+
+      def default_settings_path
+        asset "templates/settings.yml"
       end
 
     end

--- a/lib/bashly/templates/settings.yml
+++ b/lib/bashly/templates/settings.yml
@@ -1,6 +1,10 @@
 # All settings are optional (with their default values provided below), and
 # can also be set with an environment variable with the same name, capitalized
 # and prefixed by `BASHLY_` - for example: BASHLY_SOURCE_DIR
+#
+# When setting environment variables, you can use:
+# - "0", "false" or "no" to represent false
+# - "1", "true" or "yes" to represent true
 
 # The path containing the bashly configuration and source files
 source_dir: src

--- a/spec/bashly/settings_spec.rb
+++ b/spec/bashly/settings_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe Settings do
+  subject { described_class }
+
+  describe 'standard value' do
+    it "returns a predefined default value" do
+      expect(subject.tab_indent).to be false
+    end
+
+    context "when its corresponding env var is set" do
+      before do
+        Settings.tab_indent = nil
+        @original_value = ENV['BASHLY_TAB_INDENT']
+      end
+      
+      after do
+        ENV['BASHLY_TAB_INDENT'] = @original_value
+      end
+
+      it "returns true when the env var is truthy" do
+        %w[1 true yes].each do |value|
+          ENV['BASHLY_TAB_INDENT'] = value
+          expect(subject.tab_indent).to be true
+        end
+      end
+
+      it "returns false when the env var is falsy" do
+        %w[0 false no].each do |value|
+          ENV['BASHLY_TAB_INDENT'] = value
+          expect(subject.tab_indent).to be false
+        end
+      end
+
+      it "returns the env var value itself otherwise" do
+        ENV['BASHLY_TAB_INDENT'] = "anything at all"
+        expect(subject.tab_indent).to eq ENV['BASHLY_TAB_INDENT']
+      end
+
+    end
+  end
+
+  describe '::env' do
+    it "returns :development by default" do
+      expect(subject.env).to eq :development
+    end
+  end
+
+  describe '::production?' do
+    it "returns false by default" do
+      expect(subject.production?).to be false
+    end
+
+    context "when env == :production" do
+      before { subject.env = :production }
+      after { subject.env = nil }
+
+      it "returns true" do
+        expect(subject.production?).to be true
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This PR refactors the handling of settings so that user settings are merged with a default settings hash.

This is done mainly to allow future settings to have a default value of `true` and still be backwards compatible with people who already have settings that do not define these new settings.

This is related to #274 - so we can avoid using an inverted key name such as `disable_compact_flags` and instead just use `compact_flags` and have it default to true.