### PR TITLE
Add `--verbose` to `bashly validate`, to show the compiled config

### DIFF
--- a/bashly.gemspec
+++ b/bashly.gemspec
@@ -22,9 +22,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'gtx', '~> 0.1.0'
 
   s.add_runtime_dependency 'colsole', '~> 0.7'
+  s.add_runtime_dependency 'filewatcher', '~> 2.0'
+  s.add_runtime_dependency 'lp', '~> 0.2'
   s.add_runtime_dependency 'mister_bin', '~> 0.7'
   s.add_runtime_dependency 'requires', '~> 0.2'
-  s.add_runtime_dependency 'filewatcher', '~> 2.0'
 
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/DannyBen/bashly/issues",

--- a/lib/bashly/commands/validate.rb
+++ b/lib/bashly/commands/validate.rb
@@ -3,12 +3,18 @@ module Bashly
     class Validate < Base
       help "Scan the configuration file for errors"
 
-      usage "bashly validate"
+      usage "bashly validate [--verbose]"
       usage "bashly validate (-h|--help)"
+
+      option "-v --verbose", "Show the bashly configuration file prior to validating. This is useful when using split config (import) since it will show the final compiled configuration."
 
       environment "BASHLY_SOURCE_DIR", "The path containing the bashly configuration and source files [default: src]"
 
       def run
+        if args['--verbose']
+          lp config
+          puts "---"
+        end
         validate_config
         show_deprecations
         deprecations = config_validator.deprecations

--- a/spec/approvals/cli/validate/help
+++ b/spec/approvals/cli/validate/help
@@ -1,10 +1,15 @@
 Scan the configuration file for errors
 
 Usage:
-  bashly validate
+  bashly validate [--verbose]
   bashly validate (-h|--help)
 
 Options:
+  -v --verbose
+    Show the bashly configuration file prior to validating. This is useful when
+    using split config (import) since it will show the final compiled
+    configuration.
+
   -h --help
     Show this help
 

--- a/spec/approvals/cli/validate/verbose-invalid
+++ b/spec/approvals/cli/validate/verbose-invalid
@@ -1,0 +1,9 @@
+---
+name: cli
+commands:
+- name: invalid
+  help: This one will not validate
+  commands:
+    name: nested
+    help: Not an array
+---

--- a/spec/approvals/cli/validate/verbose-valid
+++ b/spec/approvals/cli/validate/verbose-valid
@@ -1,0 +1,10 @@
+---
+name: cli
+commands:
+- name: toplevel
+  help: The toplevel command namespace
+  commands:
+  - name: nested
+    help: The nested command
+---
+OK

--- a/spec/bashly/commands/validate_spec.rb
+++ b/spec/bashly/commands/validate_spec.rb
@@ -21,6 +21,29 @@ describe Commands::Validate do
     end
   end
 
+  context "with --verbose" do
+    before do
+      reset_tmp_dir create_src: true
+      cp 'spec/fixtures/workspaces/import/*'
+    end
+
+    it "shows the compiled config file prior to validation" do
+      expect { subject.run %w[validate -v] }.to output_approval('cli/validate/verbose-valid')
+    end
+
+    context "when the compiled config is invalid" do
+      before do
+        reset_tmp_dir create_src: true
+        cp 'spec/fixtures/invalid.yml', "#{source_dir}/bashly.yml"
+      end
+
+      it "still shows it prior to validation" do
+        expect { subject.run %w[validate -v] }.to raise_error(ConfigurationError)
+          .and output_approval('cli/validate/verbose-invalid')
+      end
+    end
+  end
+
   # DEPRECATION 0.8.0
   context "with deprecated command.short option" do
     before do

--- a/spec/fixtures/invalid.yml
+++ b/spec/fixtures/invalid.yml
@@ -1,0 +1,8 @@
+name: cli
+
+commands:
+- name: invalid
+  help: This one will not validate
+  commands:
+    name: nested
+    help: Not an array

--- a/spec/fixtures/workspaces/import/src/bashly.yml
+++ b/spec/fixtures/workspaces/import/src/bashly.yml
@@ -1,0 +1,7 @@
+name: cli
+
+commands:
+- name: toplevel
+  help: "The toplevel command namespace"
+  commands:
+  - import: spec/tmp/src/nested_command.sh

--- a/spec/fixtures/workspaces/import/src/nested_command.sh
+++ b/spec/fixtures/workspaces/import/src/nested_command.sh
@@ -1,0 +1,4 @@
+name: nested
+help: "The nested command"
+---
+inspect_args


### PR DESCRIPTION
When using [Split Config](https://bashly.dannyb.co/advanced/split-config/), it is sometimes hard to understand validation errors.

This PR makes it so `bashly validate --verbose` (or `bashly v -v`) also shows the "compiled" config **even if it is invalid**.

cc #279