### PR TITLE
Add command function directive

### DIFF
--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -119,6 +119,7 @@ module Bashly
       assert_optional_string "#{key}.footer", value['footer']
       assert_optional_string "#{key}.group", value['group']
       assert_optional_string "#{key}.filename", value['filename']
+      assert_optional_string "#{key}.function", value['function']
 
       assert_boolean "#{key}.private", value['private']
       assert_boolean "#{key}.default", value['default']
@@ -141,6 +142,10 @@ module Bashly
       assert_uniq "#{key}.flags", value['flags'], 'long'
       assert_uniq "#{key}.flags", value['flags'], 'short'
       assert_uniq "#{key}.args", value['args'], 'name'
+
+      if value['function']
+        assert value['function'].match(/^[a-z0-9_]+$/), "#{key}.function must contain lowercase alphanumeric characters and underscores only" 
+      end
 
       if value['default']
         assert value['args'], "#{key}.default makes no sense without args"

--- a/lib/bashly/script/command.rb
+++ b/lib/bashly/script/command.rb
@@ -9,7 +9,7 @@ module Bashly
             alias args catch_all commands completions
             default dependencies environment_variables examples
             extensible expose filename filters flags
-            footer group help name
+            footer function group help name
             private version
             short
           ]
@@ -168,7 +168,7 @@ module Bashly
 
       # Returns a unique name, suitable to be used in a bash function
       def function_name
-        full_name.to_underscore
+        options['function'] || full_name.to_underscore
       end
 
       # Returns the name of the command, including its parent name (in case

--- a/spec/approvals/validations/command_function
+++ b/spec/approvals/validations/command_function
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.function must contain lowercase alphanumeric characters and underscores only>

--- a/spec/bashly/script/command_spec.rb
+++ b/spec/bashly/script/command_spec.rb
@@ -220,6 +220,14 @@ describe Script::Command do
     it "returns the full name underscored" do
       expect(subject.function_name).to eq "docker_container_run"
     end
+
+    context "when function is provided by the user's config" do
+      let(:fixture) { :custom_function }
+
+      it "returns the requested function name" do
+        expect(subject.function_name).to eq "my_custom_function"
+      end
+    end
   end
 
   describe '#full_name' do

--- a/spec/fixtures/script/commands.yml
+++ b/spec/fixtures/script/commands.yml
@@ -102,6 +102,10 @@
   name: run
   filename: ops/run_command.sh
 
+:custom_function:
+  name: run
+  function: my_custom_function
+
 :custom_header:
   name: check
 

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -86,6 +86,11 @@
   help: command.filters should be an array of strings
   filters: [1, 2]
 
+:command_function:
+  name: invalid
+  help: command.function must match /[a-z0-9_]+/
+  function: myCamelCaseFunction
+
 :command_version:
   name: invalid
   help: version should be a string or a number


### PR DESCRIPTION
This PR adds the ability to override the internal names that bashly gives to the functions that handle a command. Normally, this should not be a concern to most people, but a typical use case is discussed in #281.