### PR TITLE
Allow command.dependencies to be a hash for custom 'how to install' messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /doc
 /Gemfile.lock
 /gems
+/spec/status.txt
 /spec/tmp
 /tmp
 /toc.txt

--- a/examples/command-examples/README.md
+++ b/examples/command-examples/README.md
@@ -66,7 +66,7 @@ commands:
   # over how the examples are displayed. Note the use of the '|-' marker
   # that tells YAML to use the string as is, including the newlines it contains.
   examples: |-
-    Upload a file 
+    Upload a file
     $ cli upload profile.png -u admin -p s3cr3t
 
     Upload a file (you will be prompted to provide a password)
@@ -137,10 +137,10 @@ Arguments:
 
 Examples:
   Upload a file
-  $ cli upload profile.png --user admin
+  $ cli upload profile.png -u admin -p s3cr3t
   
-  Upload a file and prompt for password
-  $ cli upload profile.png -u admin -p
+  Upload a file (you will be prompted to provide a password)
+  $ cli upload profile.png --user admin
 
 
 

--- a/examples/command-examples/src/bashly.yml
+++ b/examples/command-examples/src/bashly.yml
@@ -49,7 +49,7 @@ commands:
   # over how the examples are displayed. Note the use of the '|-' marker
   # that tells YAML to use the string as is, including the newlines it contains.
   examples: |-
-    Upload a file 
+    Upload a file
     $ cli upload profile.png -u admin -p s3cr3t
 
     Upload a file (you will be prompted to provide a password)

--- a/examples/dependencies/.gitignore
+++ b/examples/dependencies/.gitignore
@@ -1,1 +1,3 @@
 cli
+src/*.sh
+src/lib

--- a/examples/dependencies/README.md
+++ b/examples/dependencies/README.md
@@ -7,6 +7,7 @@ This example was generated with:
 
 ```bash
 $ bashly init
+$ bashly add colors
 # ... now edit src/bashly.yml to match the example ...
 $ bashly generate
 ```
@@ -34,6 +35,12 @@ commands:
 
 - name: upload
   help: Upload something
+
+  # Dependencies can also be defined as a hash of 'command: message' pairs.
+  # The message can use colors from the colors library (bashly add colors).
+  dependencies:
+    mini-docker: install with $(green gem install mini-docker)
+    docker: visit https://docker.com for more information
 ```
 
 
@@ -51,10 +58,8 @@ missing dependency: shmurl
 ### `$ ./cli upload`
 
 ```shell
-# this file is located in 'src/upload_command.sh'
-# code for 'cli upload' goes here
-# you can edit it freely and regenerate (it will not be overwritten)
-args: none
+missing dependency: mini-docker
+install with [32mgem install mini-docker[0m
 
 
 ```

--- a/examples/dependencies/src/bashly.yml
+++ b/examples/dependencies/src/bashly.yml
@@ -16,3 +16,9 @@ commands:
 
 - name: upload
   help: Upload something
+
+  # Dependencies can also be defined as a hash of 'command: message' pairs.
+  # The message can use colors from the colors library (bashly add colors).
+  dependencies:
+    mini-docker: install with $(green gem install mini-docker)
+    docker: visit https://docker.com for more information

--- a/examples/dependencies/src/initialize.sh
+++ b/examples/dependencies/src/initialize.sh
@@ -1,6 +1,6 @@
-# Code here runs inside the initialize() function
-# Use it for anything that you need to run before any other function, like
-# setting environment variables:
-# CONFIG_FILE=settings.ini
-#
-# Feel free to empty (but not delete) this file.
+## Code here runs inside the initialize() function
+## Use it for anything that you need to run before any other function, like
+## setting environment variables:
+## CONFIG_FILE=settings.ini
+##
+## Feel free to empty (but not delete) this file.

--- a/examples/dependencies/src/lib/colors.sh
+++ b/examples/dependencies/src/lib/colors.sh
@@ -1,0 +1,42 @@
+## Color functions [@bashly-upgrade colors]
+## This file is a part of Bashly standard library
+##
+## Usage:
+## Use any of the functions below to color or format a portion of a string.
+##
+##   echo "before $(red this is red) after"
+##   echo "before $(green_bold this is green_bold) after"
+##
+## Color output will be disabled if `NO_COLOR` environment variable is set
+## in compliance with https://no-color.org/
+##
+print_in_color() {
+  local color="$1"
+  shift
+  if [[ -z ${NO_COLOR+x} ]]; then
+    printf "$color%b\e[0m\n" "$*";
+  else
+    printf "%b\n" "$*";
+  fi
+}
+
+red() { print_in_color "\e[31m" "$*"; }
+green() { print_in_color "\e[32m" "$*"; }
+yellow() { print_in_color "\e[33m" "$*"; }
+blue() { print_in_color "\e[34m" "$*"; }
+magenta() { print_in_color "\e[35m" "$*"; }
+cyan() { print_in_color "\e[36m" "$*"; }
+bold() { print_in_color "\e[1m" "$*"; }
+underlined() { print_in_color "\e[4m" "$*"; }
+red_bold() { print_in_color "\e[1;31m" "$*"; }
+green_bold() { print_in_color "\e[1;32m" "$*"; }
+yellow_bold() { print_in_color "\e[1;33m" "$*"; }
+blue_bold() { print_in_color "\e[1;34m" "$*"; }
+magenta_bold() { print_in_color "\e[1;35m" "$*"; }
+cyan_bold() { print_in_color "\e[1;36m" "$*"; }
+red_underlined() { print_in_color "\e[4;31m" "$*"; }
+green_underlined() { print_in_color "\e[4;32m" "$*"; }
+yellow_underlined() { print_in_color "\e[4;33m" "$*"; }
+blue_underlined() { print_in_color "\e[4;34m" "$*"; }
+magenta_underlined() { print_in_color "\e[4;35m" "$*"; }
+cyan_underlined() { print_in_color "\e[4;36m" "$*"; }

--- a/examples/dependencies/src/verify_command.sh
+++ b/examples/dependencies/src/verify_command.sh
@@ -1,4 +1,0 @@
-echo "# this file is located in 'src/verify_command.sh'"
-echo "# code for 'cli verify' goes here"
-echo "# you can edit it freely and regenerate (it will not be overwritten)"
-inspect_args

--- a/examples/dependencies/test.sh
+++ b/examples/dependencies/test.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
+rm -f src/lib/colors.sh
+rm -f src/*.sh
+
 set -x
 
+bashly add colors
 bashly generate
 
 ### Try Me ###

--- a/lib/bashly/concerns/validation_helpers.rb
+++ b/lib/bashly/concerns/validation_helpers.rb
@@ -43,12 +43,19 @@ module Bashly
       end
     end
 
-    def assert_hash(key, value, whitelist = nil)
+    def assert_hash(key, value, keys: nil, of: nil)
       assert value.is_a?(Hash), "#{key} must be a hash"
-      return unless whitelist
 
-      invalid_keys = value.keys.map(&:to_sym) - whitelist
-      assert invalid_keys.empty?, "#{key} contains invalid options: #{invalid_keys.join ', '}"
+      if keys
+        invalid_keys = value.keys.map(&:to_sym) - keys
+        assert invalid_keys.empty?, "#{key} contains invalid options: #{invalid_keys.join ', '}"
+      end
+
+      return unless of
+
+      value.each do |k, v|
+        send "assert_#{of}".to_sym, "#{key}.#{k}", v
+      end
     end
 
     def assert_uniq(key, value, array_keys)

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -31,10 +31,24 @@ module Bashly
     end
 
     def assert_catch_all_hash(key, value)
-      assert_hash key, value, Script::CatchAll.option_keys
+      assert_hash key, value, keys: Script::CatchAll.option_keys
       assert_string "#{key}.label", value['label']
       assert_optional_string "#{key}.help", value['help']
       assert_boolean "#{key}.required", value['required']
+    end
+
+    def assert_dependencies(key, value)
+      return unless value
+
+      case value
+      when Array
+        assert_array key, value, of: :string
+      when Hash
+        assert_hash key, value, of: :string
+      else
+        assert [Array, Hash].include?(value.class),
+          "#{key} must be an array or a hash"
+      end
     end
 
     def assert_extensible(key, value)
@@ -51,7 +65,7 @@ module Bashly
     end
 
     def assert_arg(key, value)
-      assert_hash key, value, Script::Argument.option_keys
+      assert_hash key, value, keys: Script::Argument.option_keys
       assert_string "#{key}.name", value['name']
       assert_optional_string "#{key}.help", value['help']
       assert_optional_string "#{key}.default", value['default']
@@ -67,7 +81,7 @@ module Bashly
     end
 
     def assert_flag(key, value)
-      assert_hash key, value, Script::Flag.option_keys
+      assert_hash key, value, keys: Script::Flag.option_keys
       assert value['short'] || value['long'], "#{key} must have at least one of long or short name"
 
       refute value['allowed'] && value['completions'], "#{key} cannot have both allowed and completions"
@@ -105,7 +119,7 @@ module Bashly
     end
 
     def assert_env_var(key, value)
-      assert_hash key, value, Script::EnvironmentVariable.option_keys
+      assert_hash key, value, keys: Script::EnvironmentVariable.option_keys
       assert_string "#{key}.name", value['name']
       assert_optional_string "#{key}.help", value['help']
       assert_optional_string "#{key}.default", value['default']
@@ -113,7 +127,7 @@ module Bashly
     end
 
     def assert_command(key, value)
-      assert_hash key, value, Script::Command.option_keys
+      assert_hash key, value, keys: Script::Command.option_keys
 
       refute value['commands'] && value['args'], "#{key} cannot have both commands and args"
       refute value['commands'] && value['catch_all'], "#{key} cannot have both commands and catch_all"
@@ -133,12 +147,12 @@ module Bashly
       assert_string_or_array "#{key}.alias", value['alias']
       assert_string_or_array "#{key}.examples", value['examples']
       assert_extensible "#{key}.extensible", value['extensible']
+      assert_dependencies "#{key}.dependencies", value['dependencies']
 
       assert_array "#{key}.args", value['args'], of: :arg
       assert_array "#{key}.flags", value['flags'], of: :flag
       assert_array "#{key}.commands", value['commands'], of: :command
       assert_array "#{key}.completions", value['completions'], of: :string
-      assert_array "#{key}.dependencies", value['dependencies'], of: :string
       assert_array "#{key}.filters", value['filters'], of: :string
       assert_array "#{key}.environment_variables", value['environment_variables'], of: :env_var
 

--- a/lib/bashly/views/command/dependencies_filter.gtx
+++ b/lib/bashly/views/command/dependencies_filter.gtx
@@ -1,9 +1,13 @@
 if dependencies
   = view_marker
 
-  dependencies.each do |dependency|
+  dependencies.each do |dependency, message|
     > if ! [[ -x "$(command -v {{ dependency }})" ]]; then
     >   printf "{{ strings[:missing_dependency] % { dependency: dependency } }}\n" >&2
+    if message and !message.empty?
+      >   # shellcheck disable=SC2059
+      >   printf "{{ message }}\n" >&2
+    end
     >   exit 1
     > fi
   end

--- a/lib/bashly/views/command/fixed_flags_filter.gtx
+++ b/lib/bashly/views/command/fixed_flags_filter.gtx
@@ -4,29 +4,29 @@
 >   case "${1:-}" in
 
 if root_command?
-  = short_flag_exist?("-v") ? "--version )" : "--version | -v )"
-  >   version_command
-  >   exit
-  >   ;;
+  = short_flag_exist?("-v") ? "--version )" : "--version | -v )".indent(4)
+  >       version_command
+  >       exit
+  >       ;;
   > 
 end
 
-= short_flag_exist?("-h") ? "--help )" : "--help | -h )"
->   long_usage=yes
->   <%= function_name %>_usage
->   exit
->   ;;
+= short_flag_exist?("-h") ? "--help )" : "--help | -h )".indent(4)
+>       long_usage=yes
+>       <%= function_name %>_usage
+>       exit
+>       ;;
 > 
 
 if global_flags?
   flags.each do |flag|
-    = flag.render(:case).indent(2)
+    = flag.render(:case).indent(4)
   end
 end
 
->   * )
->     break
->     ;;
+>     * )
+>       break
+>       ;;
 >
 >   esac
 > done

--- a/spec/approvals/examples/command-examples
+++ b/spec/approvals/examples/command-examples
@@ -56,7 +56,7 @@ Arguments:
     File to upload
 
 Examples:
-  Upload a file 
+  Upload a file
   $ cli upload profile.png -u admin -p s3cr3t
   
   Upload a file (you will be prompted to provide a password)

--- a/spec/approvals/examples/dependencies
+++ b/spec/approvals/examples/dependencies
@@ -1,8 +1,10 @@
++ bashly add colors
+created src/lib/colors.sh
 + bashly generate
 creating user files in src
-skipped src/initialize.sh (exists)
-skipped src/download_command.sh (exists)
-skipped src/upload_command.sh (exists)
+created src/initialize.sh
+created src/download_command.sh
+created src/upload_command.sh
 created ./cli
 run ./cli --help to test your bash script
 + ./cli download

--- a/spec/approvals/examples/dependencies
+++ b/spec/approvals/examples/dependencies
@@ -8,7 +8,5 @@ run ./cli --help to test your bash script
 + ./cli download
 missing dependency: shmurl
 + ./cli upload
-# this file is located in 'src/upload_command.sh'
-# code for 'cli upload' goes here
-# you can edit it freely and regenerate (it will not be overwritten)
-args: none
+missing dependency: mini-docker
+install with gem install mini-docker

--- a/spec/approvals/validations/command_dependencies_invalid
+++ b/spec/approvals/validations/command_dependencies_invalid
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.dependencies must be an array or a hash>

--- a/spec/approvals/validations/command_dependencies_invalid_array
+++ b/spec/approvals/validations/command_dependencies_invalid_array
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.dependencies[0] must be a string>

--- a/spec/approvals/validations/command_dependencies_invalid_hash
+++ b/spec/approvals/validations/command_dependencies_invalid_hash
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.dependencies.docker must be a string>

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -44,6 +44,24 @@
   commands:
   - name: config
 
+:command_dependencies_invalid:
+  name: invalid
+  dependencies: 1
+
+:command_dependencies_invalid:
+  name: invalid
+  dependencies: 1
+
+:command_dependencies_invalid_array:
+  name: invalid
+  dependencies: [1, 2]
+
+:command_dependencies_invalid_hash:
+  name: invalid
+  dependencies:
+    docker: 1
+    git: 2
+
 :command_expose_invalid_type:
   name: invalid
   help: expose should be boolean or 'always'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,8 @@ ENV['TTY'] = 'off'
 ENV['COLUMNS'] = '80'
 ENV['LINES'] = '30'
 
-RSpec.configure do |c|
-  c.include SpecMixin
-  c.strip_ansi_escape = true
+RSpec.configure do |config|
+  config.include SpecMixin
+  config.example_status_persistence_file_path = 'spec/status.txt'
+  config.strip_ansi_escape = true
 end


### PR DESCRIPTION
In addition to the already existing:

```yaml
dependencies: [docker, curl]
```

we can now also do:

```yaml
dependencies:
  docker: see https://docker.com for installation instructions
  curl: to install run $(green sudo apt install curl)
```
