### PR TITLE
Change dependency command checker for testability

### DIFF
--- a/lib/bashly/views/command/dependencies_filter.gtx
+++ b/lib/bashly/views/command/dependencies_filter.gtx
@@ -2,7 +2,7 @@ if dependencies
   = view_marker
 
   dependencies.each do |dependency, message|
-    > if ! [[ -x "$(command -v {{ dependency }})" ]]; then
+    > if ! command -v {{ dependency }} >/dev/null 2>&1; then
     >   printf "{{ strings[:missing_dependency] % { dependency: dependency } }}\n" >&2
     if message and !message.empty?
       >   # shellcheck disable=SC2059


### PR DESCRIPTION
The dependency function used for checking if a command exists was returning false if the tested command was defined as a function. This made it more difficult to stub commands for testing. The new testing function works for functions as well.

```diff
- > if ! [[ -x "$(command -v {{ dependency }})" ]]; then
+ > if ! command -v {{ dependency }} >/dev/null 2>&1; then
```