### PR TITLE
Fix all shfmt offenses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       run: curl -Ls http://get.dannyb.co/rush/setup | bash
 
     - name: Install shfmt
-      run: rush snatch dannyben/shfmt
+      run: rush snatch dannyben shfmt
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env: 
-      LC_ALL: en_US.UTF-8 # consistent sort order
+      # For consistent sort order
+      LC_ALL: en_US.UTF-8 
 
     strategy:
       matrix: { ruby: ['2.7', '3.0', '3.1', 'head'] }
@@ -19,8 +20,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+    # libyaml needed for Ruby's YAML library
     - name: Install OS dependencies
       run: sudo apt-get -y install libyaml-dev
+
+    # Rush needed for easy installation of latest shfmt
+    - name: Install rush
+      run: curl -Ls http://get.dannyb.co/rush/setup | bash
+
+    - name: Install shfmt
+      run: rush snatch dannyben/shfmt
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
@@ -33,3 +42,6 @@ jobs:
 
     - name: Run shellcheck tests
       run: bundle exec run shellcheck
+
+    - name: Run shfmt tests
+      run: bundle exec run shfmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,6 @@ jobs:
     - name: Install OS dependencies
       run: sudo apt-get -y install libyaml-dev
 
-    # Rush needed for easy installation of latest shfmt
-    - name: Install rush
-      run: curl -Ls http://get.dannyb.co/rush/setup | bash
-
-    - name: Install shfmt
-      run: rush snatch dannyben shfmt
-
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with: 
@@ -39,6 +32,22 @@ jobs:
 
     - name: Run tests
       run: bundle exec rspec
+
+  static_analysis:
+    name: Static analysis of Example files
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    # Rush needed for easy installation of latest shfmt
+    - name: Install rush
+      run: curl -Ls http://get.dannyb.co/rush/setup | bash
+
+    - name: Install shfmt
+      run: rush snatch dannyben shfmt
 
     - name: Run shellcheck tests
       run: bundle exec run shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,16 @@ jobs:
     - name: Install shfmt
       run: rush snatch dannyben shfmt
 
+    # libyaml needed for Ruby's YAML library
+    - name: Install OS dependencies
+      run: sudo apt-get -y install libyaml-dev
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with: 
+        ruby-version: '3.1'
+        bundler-cache: true
+
     - name: Run shellcheck tests
       run: bundle exec run shellcheck
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ usually handled by a framework in any other programming language.
 It is available both as a [ruby gem](https://rubygems.org/gems/bashly) and as
 a [docker image](https://hub.docker.com/r/dannyben/bashly).
 
-
 ## Documentation
 
 - [Bashly Homepage][docs]
@@ -49,6 +48,7 @@ a [docker image](https://hub.docker.com/r/dannyben/bashly).
 Bashly is responsible for:
 
 - Generating a **single, standalone bash script**.
+- Generating a **human readable, shellcheck-compliant and shfmt-compliant script**.
 - Generating **usage texts** and help screens, showing your tool's arguments, flags and commands (works for sub-commands also).
 - Parsing the user's command line and extracting:
   - Optional or required **positional arguments**.
@@ -72,14 +72,11 @@ to contribute, feel free to [open an issue][issues] or
 
 Visit the *[How to contribute][contributing]* page for more information.
 
-
 ## Stargazers and Forkers
 
 [![Stargazers repo roster for @DannyBen/bashly](https://reporoster.com/stars/DannyBen/bashly)](https://github.com/DannyBen/bashly/stargazers)
 
 [![Forkers repo roster for @DannyBen/bashly](https://reporoster.com/forks/DannyBen/bashly)](https://github.com/DannyBen/bashly/network/members)
-
-
 
 [issues]: https://github.com/DannyBen/bashly/issues
 [discussions]: https://github.com/DannyBen/bashly/discussions

--- a/Runfile
+++ b/Runfile
@@ -35,14 +35,15 @@ end
 help   "Run shfmt checks on all examples"
 action :shfmt do
   Example.executables.each do |example|
-    if File.exist? example
-      success = system "shfmt -d -i 2 -ci #{example}"
-      color = success ? 'txtgrn' : 'txtred'
-      say "- shfmt !#{color}!#{example}"
-      exit 1 unless success
-    else
-      say "- skip       !txtcyn!#{example}"
+    if example == 'examples/heredoc/cli' || !File.exist?(example)
+      say "- skip  !txtcyn!#{example}"
+      next
     end
+
+    success = system "shfmt -d -i 2 -ci #{example}"
+    color = success ? 'txtgrn' : 'txtred'
+    say "- shfmt !#{color}!#{example}"
+    exit 1 unless success
   end
 end
 

--- a/examples/filters/README.md
+++ b/examples/filters/README.md
@@ -59,7 +59,7 @@ commands:
 # Print an error string if docker is not running.
 # The script will automatically exit if this function prints anything.
 filter_docker_running() {
-  docker info > /dev/null 2>&1 || echo "Docker must be running"
+  docker info >/dev/null 2>&1 || echo "Docker must be running"
 }
 
 # This is just a sample filter designed to always fail

--- a/examples/filters/src/lib/filters.sh
+++ b/examples/filters/src/lib/filters.sh
@@ -6,7 +6,7 @@
 # Print an error string if docker is not running.
 # The script will automatically exit if this function prints anything.
 filter_docker_running() {
-  docker info > /dev/null 2>&1 || echo "Docker must be running"
+  docker info >/dev/null 2>&1 || echo "Docker must be running"
 }
 
 # This is just a sample filter designed to always fail

--- a/examples/heredoc-alt/README.md
+++ b/examples/heredoc-alt/README.md
@@ -40,7 +40,7 @@ echo "$text"
 
 ```bash
 message1() {
-  cat << EOF
+  cat <<EOF
 this is a
   multiline
     heredoc text

--- a/examples/heredoc-alt/src/lib/heredocs.sh
+++ b/examples/heredoc-alt/src/lib/heredocs.sh
@@ -1,5 +1,5 @@
 message1() {
-  cat << EOF
+  cat <<EOF
 this is a
   multiline
     heredoc text

--- a/lib/bashly/views/command/command_fallback.gtx
+++ b/lib/bashly/views/command/command_fallback.gtx
@@ -24,6 +24,7 @@ elsif extensible.is_a? String
   >     printf "{{ strings[:invalid_command] }}\n" "$action" >&2
   >     exit 1
   >   fi
+  >   ;;
   >
 
 elsif extensible
@@ -34,6 +35,7 @@ elsif extensible
   >     printf "{{ strings[:invalid_command] }}\n" "$action" >&2
   >     exit 1
   >   fi
+  >   ;;
   >
 
 else

--- a/lib/bashly/views/command/default_assignments.gtx
+++ b/lib/bashly/views/command/default_assignments.gtx
@@ -2,11 +2,11 @@ if default_args.any? or default_flags.any?
   = view_marker
 
   default_args.each do |arg|
-    > [[ -n ${args[{{ arg.name }}]:-} ]] || args[{{ arg.name }}]="{{ arg.default }}"
+    > [[ -n ${args['{{ arg.name }}']:-} ]] || args['{{ arg.name }}']="{{ arg.default }}"
   end
 
   default_flags.each do |flag|
-    > [[ -n ${args[{{ flag.long }}]:-} ]] || args[{{ flag.long }}]="{{ flag.default }}"
+    > [[ -n ${args['{{ flag.long }}']:-} ]] || args['{{ flag.long }}']="{{ flag.default }}"
   end
 
   >

--- a/lib/bashly/views/command/fixed_flags_filter.gtx
+++ b/lib/bashly/views/command/fixed_flags_filter.gtx
@@ -4,14 +4,14 @@
 >   case "${1:-}" in
 
 if root_command?
-  = short_flag_exist?("-v") ? "--version)" : "--version | -v)".indent(4)
+  = short_flag_exist?("-v") ? "--version)".indent(4) : "--version | -v)".indent(4)
   >       version_command
   >       exit
   >       ;;
   > 
 end
 
-= short_flag_exist?("-h") ? "--help)" : "--help | -h)".indent(4)
+= short_flag_exist?("-h") ? "--help)".indent(4) : "--help | -h)".indent(4)
 >       long_usage=yes
 >       <%= function_name %>_usage
 >       exit

--- a/lib/bashly/views/command/fixed_flags_filter.gtx
+++ b/lib/bashly/views/command/fixed_flags_filter.gtx
@@ -4,14 +4,14 @@
 >   case "${1:-}" in
 
 if root_command?
-  = short_flag_exist?("-v") ? "--version)".indent(4) : "--version | -v)".indent(4)
+  = (short_flag_exist?("-v") ? "--version)" : "--version | -v)").indent(4)
   >       version_command
   >       exit
   >       ;;
   > 
 end
 
-= short_flag_exist?("-h") ? "--help)".indent(4) : "--help | -h)".indent(4)
+= (short_flag_exist?("-h") ? "--help)" : "--help | -h)").indent(4)
 >       long_usage=yes
 >       <%= function_name %>_usage
 >       exit

--- a/lib/bashly/views/command/parse_requirements_case_catch_all.gtx
+++ b/lib/bashly/views/command/parse_requirements_case_catch_all.gtx
@@ -3,9 +3,9 @@
 if args.any?
   condition = "if"
   args.each do |arg|
-    > {{ condition }} [[ -z ${args[{{ arg.name }}]+x} ]]; then
+    > {{ condition }} [[ -z ${args['{{ arg.name }}']+x} ]]; then
     =   arg.render(:validations).indent 2
-    >   args[{{ arg.name }}]=$1
+    >   args['{{ arg.name }}']=$1
     >   shift
     
     condition = "elif"

--- a/lib/bashly/views/command/parse_requirements_case_repeatable.gtx
+++ b/lib/bashly/views/command/parse_requirements_case_repeatable.gtx
@@ -3,16 +3,16 @@
 condition = "if"
 args.each do |arg|
   = arg.render(:validations)
-  > {{ condition }} [[ -z ${args[{{ arg.name }}]+x} ]]; then
+  > {{ condition }} [[ -z ${args['{{ arg.name }}']+x} ]]; then
   if arg.repeatable
-    >   args[{{ arg.name }}]="\"$1\""
+    >   args['{{ arg.name }}']="\"$1\""
     >   shift
     > else
-    >   args[{{ arg.name }}]="${args[{{ arg.name }}]} \"$1\""
+    >   args['{{ arg.name }}']="${args[{{ arg.name }}]} \"$1\""
     >   shift
 
   else
-    >   args[{{ arg.name }}]=$1
+    >   args['{{ arg.name }}']=$1
     >   shift
 
   end

--- a/lib/bashly/views/command/parse_requirements_case_simple.gtx
+++ b/lib/bashly/views/command/parse_requirements_case_simple.gtx
@@ -3,9 +3,9 @@
 if args.any?
   condition = "if"
   args.each do |arg|
-    > {{ condition }} [[ -z ${args[{{ arg.name }}]+x} ]]; then
+    > {{ condition }} [[ -z ${args['{{ arg.name }}']+x} ]]; then
     > {{ arg.render(:validations).indent 2 }}
-    >   args[{{ arg.name }}]=$1
+    >   args['{{ arg.name }}']=$1
     >   shift
 
     condition = "elif"

--- a/lib/bashly/views/command/required_args_filter.gtx
+++ b/lib/bashly/views/command/required_args_filter.gtx
@@ -2,7 +2,7 @@ if required_args.any?
   = view_marker
 
   required_args.each do |arg|
-    > if [[ -z ${args[{{ arg.name }}]+x} ]]; then
+    > if [[ -z ${args['{{ arg.name }}']+x} ]]; then
     >   printf "{{ strings[:missing_required_argument] % { arg: arg.name.upcase, usage: usage_string } }}\n" >&2
     >   exit 1
     > fi

--- a/lib/bashly/views/command/required_flags_filter.gtx
+++ b/lib/bashly/views/command/required_flags_filter.gtx
@@ -2,7 +2,7 @@ if required_flags.any?
   = view_marker
 
   required_flags.each do |flag|
-    > if [[ -z ${args[{{ flag.long }}]+x} ]]; then
+    > if [[ -z ${args['{{ flag.long }}']+x} ]]; then
     >   printf "{{ strings[:missing_required_flag] % { usage: flag.usage_string } }}\n" >&2
     >   exit 1
     > fi

--- a/lib/bashly/views/command/run.gtx
+++ b/lib/bashly/views/command/run.gtx
@@ -11,7 +11,7 @@
 
 deep_commands.each do |command|
   >     "{{ command.action_name }}")
-  >       if [[ ${args[--help]:-} ]]; then
+  >       if [[ ${args['--help']:-} ]]; then
   >         long_usage=yes
   >         {{ command.function_name }}_usage
   >       else

--- a/lib/bashly/views/command/whitelist_filter.gtx
+++ b/lib/bashly/views/command/whitelist_filter.gtx
@@ -12,7 +12,7 @@ if whitelisted_args.any? or whitelisted_flags.any?
       > done
 
     else
-      > if [[ ! ${args[{{ arg.name }}]} =~ ^({{ arg.allowed.join '|' }})$ ]]; then
+      > if [[ ! ${args['{{ arg.name }}']} =~ ^({{ arg.allowed.join '|' }})$ ]]; then
       >   printf "%s\n" "{{ strings[:disallowed_argument] % { name: arg.name, allowed: arg.allowed.join(', ') } }}" >&2
       >   exit 1
       > fi
@@ -31,7 +31,7 @@ if whitelisted_args.any? or whitelisted_flags.any?
       > done
     
     else
-      > if [[ ! ${args[{{ flag.name }}]} =~ ^({{ flag.allowed.join '|' }})$ ]]; then
+      > if [[ ! ${args['{{ flag.name }}']} =~ ^({{ flag.allowed.join '|' }})$ ]]; then
       >   printf "%s\n" "{{ strings[:disallowed_flag] % { name: flag.name, allowed: flag.allowed.join(', ') } }}" >&2
       >   exit 1
       > fi

--- a/lib/bashly/views/flag/case_arg.gtx
+++ b/lib/bashly/views/flag/case_arg.gtx
@@ -4,14 +4,14 @@
 = render(:validations).indent 2
 
 if repeatable
-  >   if [[ -z ${args[{{ name }}]+x} ]]; then
-  >     args[{{ name }}]="\"$2\""
+  >   if [[ -z ${args['{{ name }}']+x} ]]; then
+  >     args['{{ name }}']="\"$2\""
   >   else
-  >     args[{{ name }}]="${args[{{ name }}]} \"$2\""
+  >     args['{{ name }}']="${args[{{ name }}]} \"$2\""
   >   fi
 
 else
-  >   args[{{ name }}]="$2"
+  >   args['{{ name }}']="$2"
 
 end
 

--- a/lib/bashly/views/flag/case_no_arg.gtx
+++ b/lib/bashly/views/flag/case_no_arg.gtx
@@ -1,9 +1,9 @@
 = view_marker
 
 if repeatable
-  > ((args[<%= name %>]+=1))
+  > ((args['<%= name %>'] += 1))
 else
-  > args[<%= name %>]=1
+  > args['<%= name %>']=1
 end
 
 > shift

--- a/lib/bashly/views/flag/conflicts.gtx
+++ b/lib/bashly/views/flag/conflicts.gtx
@@ -3,7 +3,7 @@ if conflicts
   = view_marker
   
   if conflicts.count == 1
-    > if [[ -n "${args[{{ conflicts.first }}]:-}" ]]; then
+    > if [[ -n "${args['{{ conflicts.first }}']:-}" ]]; then
     >   printf "{{ strings[:conflicting_flags] }}\n" "$key" "{{ conflicts.first }}" >&2
     >   exit 1
     > fi


### PR DESCRIPTION
Closes #313 

This PR makes all examples scripts pass shfmt by adjusting some minor offenses.
The most high profile adjustment, is to change all occurrences of `$arg[key]` to `$arg['key']`, since the generated script will fail shfmt if the key contains a hyphen (https://github.com/mvdan/sh/issues/956).