### PR TITLE
Fix static analysis in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,9 @@ jobs:
         ruby-version: '3.1'
         bundler-cache: true
 
+    - name: Generate all subjects
+      run: bundle exec run examples regen
     - name: Run shellcheck tests
       run: bundle exec run shellcheck
-
     - name: Run shfmt tests
       run: bundle exec run shfmt

--- a/Runfile
+++ b/Runfile
@@ -70,9 +70,22 @@ action :changelog do
   File.write "CHANGELOG.md", File.read("CHANGELOG.md").gsub('repeatableflags', 'repeatable flags')
 end
 
+command :examples
+
+help   "Regenerate example scripts"
+action :regen do
+  # Patch the PATH to allow the extensible example to run properly
+  ENV['PATH']="#{Dir.pwd}/examples/extensible:#{ENV['PATH']}"
+  Example.all.each do |example|
+    say example.dir
+    Dir.chdir example.dir do
+      system 'bash test.sh >/dev/null 2>&1'
+    end
+  end
+end
+
 help   "Append the content of bashly.yml to all example READMEs"
-action :examples do
-  # Disable color output (for the color examples)
+action :readme do
   ENV['NO_COLOR']='1'
   
   # Patch the PATH to allow the extensible example to run properly
@@ -82,6 +95,8 @@ action :examples do
     example.regenerate_readme
   end
 end
+
+endcommand
 
 require_relative 'helpers/release'
 require './debug.rb' if File.exist? 'debug.rb'

--- a/Runfile
+++ b/Runfile
@@ -21,6 +21,7 @@ end
 
 help   "Run shellcheck on all examples"
 action :shellcheck do
+  allowed_skips = 1
   Example.executables.each do |example|
     if File.exist? example
       success = system "shellcheck #{example}"
@@ -29,15 +30,26 @@ action :shellcheck do
       exit 1 unless success
     else
       say "- skip       !txtcyn!#{example}"
+      allowed_skips -= 1
+      if allowed_skips < 0
+        say "- aborted: too many skips"
+        exit 1
+      end
     end
   end
 end
 
 help   "Run shfmt checks on all examples"
 action :shfmt do
+  allowed_skips = 2
   Example.executables.each do |example|
     if example == 'examples/heredoc/cli' || !File.exist?(example)
       say "- skip  !txtcyn!#{example}"
+      allowed_skips -= 1
+      if allowed_skips < 0
+        say "- aborted: too many skips"
+        exit 1
+      end
       next
     end
 

--- a/examples/custom-strings/README.md
+++ b/examples/custom-strings/README.md
@@ -81,13 +81,11 @@ usage: download SOURCE [OPTIONS]
 download - Sample minimal application with custom strings
 
 == Usage ==
-
   download SOURCE [OPTIONS]
   download --help | -h
   download --version | -v
 
 == Options ==
-  
   --help, -h
     Show this helpful help
 
@@ -98,7 +96,6 @@ download - Sample minimal application with custom strings
     Target directory
 
 == Arguments ==
-    
   SOURCE
     URL to download from
 


### PR DESCRIPTION
The static analysis workflow was reporting success when it in fact, did nothing.
This is due to the fact that:

1. The example executables were not generated in this job, since the executables are gitignored and should be generated.
2. The shellcheck/shfmt testers were skipping examples with missing executables.

The fix:

1. Add a task to generate examples.
2. Make sure the shellcheck/shfmt tasks fail if there are more than X skips.
