### PR TITLE
Change settings.strict to allow any string

### DIFF
--- a/lib/bashly/libraries/settings/settings.yml
+++ b/lib/bashly/libraries/settings/settings.yml
@@ -18,10 +18,14 @@ config_path: "%{source_dir}/bashly.yml"
 # The path to use for creating the bash script
 target_dir: .
 
-# The path to use for upgrading library files, relative to the source dir
+# The path to use for common library files, relative to the source dir
 lib_dir: lib
 
-# When true, enable bash strict mode (set -euo pipefail)
+# Configure the bash options that will be added to the initialize function:
+# strict: true       Bash strict mode (set -euo pipefail)
+# strict: false      Only exit on errors (set -e)
+# strict: ''         Do not add any 'set' directive
+# strict: <string>   Add any other custom 'set' directive
 strict: false
 
 # When true, the generated script will use tab indentation instead of spaces
@@ -33,11 +37,11 @@ tab_indent: false
 compact_short_flags: true
 
 # Set to 'production' or 'development':
-# - production    generate a smaller script, without file markers
-# - development   generate with file markers
+# env: production    Generate a smaller script, without file markers
+# env: development   Generate with file markers
 env: development
 
-# The extension to use when reading/writing partial script snippets.
+# The extension to use when reading/writing partial script snippets
 partials_extension: sh
 
 # Display various usage elements in color by providing the name of the color

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -55,6 +55,16 @@ module Bashly
         @strict ||= get :strict
       end
 
+      def strict_string
+        if Settings.strict.is_a? String
+          Settings.strict
+        elsif Settings.strict
+          'set -euo pipefail'
+        else
+          'set -e'
+        end
+      end
+
       def tab_indent
         @tab_indent ||= get :tab_indent
       end

--- a/lib/bashly/views/command/initialize.gtx
+++ b/lib/bashly/views/command/initialize.gtx
@@ -3,7 +3,7 @@
 > initialize() {
 >   version="<%= version %>"
 >   long_usage=''
->   {{ Settings.strict ? "set -euo pipefail" : "set -e" }}
+>   {{ Settings.strict_string }}
 > 
 
 if root_command?

--- a/spec/bashly/settings_spec.rb
+++ b/spec/bashly/settings_spec.rb
@@ -55,4 +55,34 @@ describe Settings do
       end
     end
   end
+
+  describe 'strict_string' do
+    original_value = Settings.strict
+
+    after { subject.strict = original_value }
+
+    context 'when strict is true' do
+      before { subject.strict = true }
+
+      it 'returns "set -euo pipefail"' do
+        expect(subject.strict_string).to eq 'set -euo pipefail'
+      end
+    end
+
+    context 'when strict is false' do
+      before { subject.strict = false }
+
+      it 'returns "set -e"' do
+        expect(subject.strict_string).to eq 'set -e'
+      end
+    end
+
+    context 'when strict is string' do
+      before { subject.strict = 'set -o pipefail' }
+
+      it 'returns the string as is' do
+        expect(subject.strict_string).to eq 'set -o pipefail'
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ include SpecMixin
 # Set up working directory for the specs
 Settings.source_dir = 'spec/tmp/src'
 Settings.target_dir = 'spec/tmp'
-Settings.strict = true # generate scripts with `set -euo pipefile`
+Settings.strict = true # generate scripts with `set -euo pipefail`
 Settings.env = :development
 reset_tmp_dir
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ include SpecMixin
 # Set up working directory for the specs
 Settings.source_dir = 'spec/tmp/src'
 Settings.target_dir = 'spec/tmp'
-Settings.strict = '1' # generate scripts with `set -euo pipefile`
+Settings.strict = true # generate scripts with `set -euo pipefile`
 Settings.env = :development
 reset_tmp_dir
 


### PR DESCRIPTION
Allow `settings.strict` to accept any custom string, in case the developer does not want `set -e` nor `set -euo pipefail`.

addresses #352