### PR TITLE
Implement Support for Alternate Dependencies

### DIFF
--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -50,7 +50,19 @@ module Bashly
       when Array
         assert_array key, value, of: :string
       when Hash
-        assert_hash key, value, of: :string
+        assert_hash key, value
+
+        if value.any? { |_k, v| v.is_a?(Hash) }
+          value.each do |k, v|
+            subkey = "#{key}.#{k}"
+
+            assert_hash subkey, v, keys: %i[commands message]
+            assert_array "#{subkey}.commands", v['commands'], of: :string
+            assert_string "#{subkey}.message", v['message']
+          end
+        else
+          assert_hash key, value, of: :string
+        end
       else
         assert [Array, Hash].include?(value.class),
           "#{key} must be an array or a hash"

--- a/lib/bashly/views/command/dependencies_filter.gtx
+++ b/lib/bashly/views/command/dependencies_filter.gtx
@@ -1,8 +1,22 @@
 if dependencies
   = view_marker
 
+  > local result
+  >
+
   dependencies.each do |dependency, message|
-    > if ! command -v {{ dependency }} >/dev/null 2>&1; then
+    if message.is_a? Hash
+      command = message['commands'].join(' ')
+      key = dependency
+      message = message['message']
+    else
+      command = key = dependency
+    end
+
+    > result="$(command -v {{ command }} 2>/dev/null | head -1)"
+    > if ((${#result} > 0)); then
+    >   dependencies['{{ key }}']="${result}"
+    > else
     >   printf "{{ strings[:missing_dependency] % { dependency: dependency } }}\n" >&2
     if message and !message.empty?
       >   printf "%s\n" "{{ message }}" >&2

--- a/lib/bashly/views/command/run.gtx
+++ b/lib/bashly/views/command/run.gtx
@@ -2,6 +2,8 @@
 
 > run() {
 >   declare -A args=()
+>   # shellcheck dependencies=SC2034
+>   declare -A dependencies=()
 >   declare -a other_args=()
 >   declare -a input=()
 >   normalize_input "$@"


### PR DESCRIPTION
Resolves #354

The change to `config_validator.rb` is my least favourite part of this pass. However, it seems cleaner to reimplement the nested portions of `assert_hash` with specific handling. I suspect that some of this could be simplified, but I also made the simplifying assumption that if you’re specifying *one* hash value implementation for dependencies, you should specify them all that way.

The changes to `run.gtx` are required to prevent shellcheck failure since `$dependencies` is unused otherwise. This could be changed to stay within `parse_requirements`, but it would require `declare -gA dependencies` above `local result` with the same shellcheck or some otherwise mostly-harmless access of the variable. The `-gA` is required so that the variable is visible outside of `parse_requirements`, since `declare` inside of a function is the same as `local`.

The otherwise mostly-harmless access could be something like:

```
> if ((${#dependencies[@]} != {{ dependencies.size }})); then
>   printf "Missing dependencies\n" >&2
> fi
```

I have not updated any documentation as I’m not sure that this is the right implementation that you were thinking of. I will note that it *does work* in my tests.