### PR TITLE
Add validation alert when `allowed` is provided without either a `default` or `required`

### DIFF
--- a/examples/completions/README.md
+++ b/examples/completions/README.md
@@ -60,6 +60,8 @@ commands:
       - curl
       - wget
 
+    default: curl
+
   examples:
   - cli download example.com
   - cli download example.com ./output -f

--- a/examples/completions/src/bashly.yml
+++ b/examples/completions/src/bashly.yml
@@ -38,6 +38,8 @@ commands:
       - curl
       - wget
 
+    default: curl
+
   examples:
   - cli download example.com
   - cli download example.com ./output -f

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -101,6 +101,11 @@ module Bashly
       refute value['name'].match(/^-/), "#{key}.name must not start with '-'"
 
       refute value['required'] && value['default'], "#{key} cannot have both required and default"
+
+      if value['allowed']
+        assert (value['required'] || value['default']),
+          "#{key}.allowed does not make sense without either default or required"
+      end
     end
 
     def assert_flag(key, value)
@@ -135,6 +140,8 @@ module Bashly
 
       if value['allowed']
         assert value['arg'], "#{key}.allowed does not make sense without arg"
+        assert (value['required'] || value['default']),
+          "#{key}.allowed does not make sense without either default or required"
       end
 
       if value['completions']


### PR DESCRIPTION
cc #368

The `arg.allowed` and `flag.allowed` options state that this is a whitelist, which means it will **always** include one of the provided allowed options.

This means that the argument or flag must be either `required: true` or have a `default` value.

This PR adds a validation that one of these cases are met.