### PR TITLE
Fix `arg.allowed` and `flag.allowed` to allow setting without `required` or `default`

### DIFF
--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -101,11 +101,6 @@ module Bashly
       refute value['name'].match(/^-/), "#{key}.name must not start with '-'"
 
       refute value['required'] && value['default'], "#{key} cannot have both nub`required` and nub`default`"
-
-      if value['allowed']
-        assert (value['required'] || value['default']),
-          "#{key}.allowed does not make sense without either nub`default` or nub`required`"
-      end
     end
 
     def assert_flag(key, value)
@@ -140,8 +135,6 @@ module Bashly
 
       if value['allowed']
         assert value['arg'], "#{key}.allowed does not make sense without nub`arg`"
-        assert (value['required'] || value['default']),
-          "#{key}.allowed does not make sense without either nub`default` or nub`required`"
       end
 
       if value['completions']

--- a/lib/bashly/views/command/whitelist_filter.gtx
+++ b/lib/bashly/views/command/whitelist_filter.gtx
@@ -12,7 +12,7 @@ if whitelisted_args.any? or whitelisted_flags.any?
       > done
 
     else
-      > if [[ ! ${args['{{ arg.name }}']} =~ ^({{ arg.allowed.join '|' }})$ ]]; then
+      > if [[ -n ${args['{{ arg.name }}']} ]] && [[ ! ${args['{{ arg.name }}']} =~ ^({{ arg.allowed.join '|' }})$ ]]; then
       >   printf "%s\n" "{{ strings[:disallowed_argument] % { name: arg.name, allowed: arg.allowed.join(', ') } }}" >&2
       >   exit 1
       > fi
@@ -31,7 +31,7 @@ if whitelisted_args.any? or whitelisted_flags.any?
       > done
     
     else
-      > if [[ ! ${args['{{ flag.name }}']} =~ ^({{ flag.allowed.join '|' }})$ ]]; then
+      > if [[ ${args['{{ flag.name }}']} ]] && [[ ! ${args['{{ flag.name }}']} =~ ^({{ flag.allowed.join '|' }})$ ]]; then
       >   printf "%s\n" "{{ strings[:disallowed_flag] % { name: flag.name, allowed: flag.allowed.join(', ') } }}" >&2
       >   exit 1
       > fi

--- a/spec/approvals/fixtures/whitelist-optional
+++ b/spec/approvals/fixtures/whitelist-optional
@@ -1,0 +1,43 @@
++ bundle exec bashly generate
+creating user files in src
+created src/root_command.sh
+created ./cli
+run ./cli --help to test your bash script
++ ./cli
+# this file is located in 'src/root_command.sh'
+# you can edit it freely and regenerate (it will not be overwritten)
+args: none
++ ./cli -h
+cli - Test that whitelist can be optional and without a default value
+
+Usage:
+  cli [ACTION] [OPTIONS]
+  cli --help | -h
+  cli --version | -v
+
+Options:
+  --notify HANDLER
+    Send notification using this handler
+    Allowed: slack, webhook
+
+  --help, -h
+    Show this help
+
+  --version, -v
+    Show version number
+
+Arguments:
+  ACTION
+    Action to run on exit
+    Allowed: push, commit
+
++ ./cli invalid
+action must be one of: push, commit
++ ./cli --notify snail_mail
+--notify must be one of: slack, webhook
++ ./cli push --notify slack
+# this file is located in 'src/root_command.sh'
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[action]} = push
+- ${args[--notify]} = slack

--- a/spec/fixtures/workspaces/whitelist-optional/.gitignore
+++ b/spec/fixtures/workspaces/whitelist-optional/.gitignore
@@ -1,0 +1,2 @@
+src/*.sh
+cli

--- a/spec/fixtures/workspaces/whitelist-optional/README.md
+++ b/spec/fixtures/workspaces/whitelist-optional/README.md
@@ -1,0 +1,3 @@
+This fixture tests that whitelist args and flags can be optional and without a
+default value.
+ref: https://github.com/DannyBen/bashly/issues/368

--- a/spec/fixtures/workspaces/whitelist-optional/src/bashly.yml
+++ b/spec/fixtures/workspaces/whitelist-optional/src/bashly.yml
@@ -1,0 +1,14 @@
+name: cli
+help: Test that whitelist can be optional and without a default value
+version: 0.1.0
+
+args:
+- name: action
+  help: Action to run on exit
+  allowed: [push, commit]
+
+flags:
+- long: --notify
+  arg: handler
+  help: Send notification using this handler
+  allowed: [slack, webhook]

--- a/spec/fixtures/workspaces/whitelist-optional/test.sh
+++ b/spec/fixtures/workspaces/whitelist-optional/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+rm -f ./src/*.sh
+
+set -x
+
+bundle exec bashly generate
+
+./cli
+./cli -h
+./cli invalid
+./cli --notify snail_mail
+./cli push --notify slack


### PR DESCRIPTION
cc #368

This is a revert of #370 plus a fix to allow the whitelist to be optional and without a default value.
