### PR TITLE
Fix `default` and `required` for flags with a `short` name only

### DIFF
--- a/lib/bashly/views/command/default_assignments.gtx
+++ b/lib/bashly/views/command/default_assignments.gtx
@@ -6,7 +6,7 @@ if default_args.any? or default_flags.any?
   end
 
   default_flags.each do |flag|
-    > [[ -n ${args['{{ flag.long }}']:-} ]] || args['{{ flag.long }}']="{{ flag.default }}"
+    > [[ -n ${args['{{ flag.name }}']:-} ]] || args['{{ flag.name }}']="{{ flag.default }}"
   end
 
   >

--- a/lib/bashly/views/command/required_flags_filter.gtx
+++ b/lib/bashly/views/command/required_flags_filter.gtx
@@ -2,7 +2,7 @@ if required_flags.any?
   = view_marker
 
   required_flags.each do |flag|
-    > if [[ -z ${args['{{ flag.long }}']+x} ]]; then
+    > if [[ -z ${args['{{ flag.name }}']+x} ]]; then
     >   printf "{{ strings[:missing_required_flag] % { usage: flag.usage_string } }}\n" >&2
     >   exit 1
     > fi

--- a/spec/approvals/fixtures/short-flag
+++ b/spec/approvals/fixtures/short-flag
@@ -1,0 +1,19 @@
++ bundle exec bashly generate
+creating user files in src
+created src/root_command.sh
+created ./cli
+run ./cli --help to test your bash script
++ ./cli
+missing required flag: -o PATH
++ ./cli -o /tmp
+# this file is located in 'src/root_command.sh'
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[-f]} = html
+- ${args[-o]} = /tmp
++ ./cli -o /tmp -f json
+# this file is located in 'src/root_command.sh'
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[-f]} = json
+- ${args[-o]} = /tmp

--- a/spec/fixtures/workspaces/short-flag/.gitignore
+++ b/spec/fixtures/workspaces/short-flag/.gitignore
@@ -1,0 +1,2 @@
+cli
+src/*.sh

--- a/spec/fixtures/workspaces/short-flag/README.md
+++ b/spec/fixtures/workspaces/short-flag/README.md
@@ -1,0 +1,2 @@
+This fixture tests that short flags default and required work properly
+Reference issue: https://github.com/DannyBen/bashly/issues/373

--- a/spec/fixtures/workspaces/short-flag/src/bashly.yml
+++ b/spec/fixtures/workspaces/short-flag/src/bashly.yml
@@ -1,0 +1,12 @@
+name: cli
+
+flags:
+  - short: -f
+    arg: format
+    help: Set format
+    default: html
+
+  - short: -o
+    arg: path
+    help: Output to path
+    required: true

--- a/spec/fixtures/workspaces/short-flag/test.sh
+++ b/spec/fixtures/workspaces/short-flag/test.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# This fixture tests that alias command codes work properly
-# It is executed as part of the Runfile examples test
-# Reference issue: https://github.com/DannyBen/bashly/issues/16
-
 rm -f ./src/*.sh
 rm -f ./cli
 

--- a/spec/fixtures/workspaces/short-flag/test.sh
+++ b/spec/fixtures/workspaces/short-flag/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This fixture tests that alias command codes work properly
+# It is executed as part of the Runfile examples test
+# Reference issue: https://github.com/DannyBen/bashly/issues/16
+
+rm -f ./src/*.sh
+rm -f ./cli
+
+set -x
+
+bundle exec bashly generate
+
+./cli
+./cli -o /tmp
+./cli -o /tmp -f json


### PR DESCRIPTION
cc #373