### PR TITLE
Feature: enable validation and intellisence for all examples

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "yaml.schemas": {
+        "schemas/bashly.json": "examples/*/src/bashly.yml",
+        "schemas/strings.json": "examples/*/src/bashly-strings.yml",
+        "schemas/settings.json": "examples/*/settings.yml"
+    }
+}


### PR DESCRIPTION
YAML Red Hat extension needs to download and cache JSON schemas before enable their usage if they are remote ones. But if they local, no internet connection is required after cloning this repo, as local schemas for validation are used. So it's just a small addition to make working on examples more convenient.

Note that after my PR in SchemaStore is merged local schemas are still going to be used, they have precedence over remote ones as they explicitly defined in VS Code config.