### PR TITLE
Add bashly interactive shell

### DIFF
--- a/lib/bashly/cli.rb
+++ b/lib/bashly/cli.rb
@@ -15,6 +15,7 @@ module Bashly
       runner.route 'generate',  to: Commands::Generate
       runner.route 'add',       to: Commands::Add
       runner.route 'doc',       to: Commands::Doc
+      runner.route 'shell',     to: Commands::Shell unless ENV['BASHLY_SHELL']
 
       runner
     end

--- a/lib/bashly/commands/doc.rb
+++ b/lib/bashly/commands/doc.rb
@@ -2,7 +2,6 @@ module Bashly
   module Commands
     class Doc < Base
       summary 'Show bashly reference documentation'
-      help 'This command displays bite-sized help for all the bashly configuration options in the terminal.'
 
       usage 'bashly doc [SEARCH] [--index]'
       usage 'bashly doc (-h|--help)'

--- a/lib/bashly/commands/init.rb
+++ b/lib/bashly/commands/init.rb
@@ -2,7 +2,7 @@ module Bashly
   module Commands
     class Init < Base
       summary 'Initialize a new workspace'
-      help 'This command will create the source folder, and place a template configuration file in it.'
+      help 'Create the bashly source folder, and place a template configuration file in it'
 
       usage 'bashly init [--minimal]'
       usage 'bashly init (-h|--help)'

--- a/lib/bashly/commands/shell.rb
+++ b/lib/bashly/commands/shell.rb
@@ -33,7 +33,7 @@ module Bashly
       end
 
       def autocomplete
-        @autocomplete ||= %w[--help] + runner.commands.keys
+        @autocomplete ||= %w[help version] + runner.commands.keys
       end
     end
   end

--- a/lib/bashly/commands/shell.rb
+++ b/lib/bashly/commands/shell.rb
@@ -13,12 +13,13 @@ module Bashly
       end
 
     private
+
       def terminal
         @terminal ||= begin
           terminal = MisterBin::Terminal.new runner, {
             autocomplete: autocomplete,
             show_usage:   true,
-            prompt:       "\n\e[33m\e[1mbashly\e[0m > "
+            prompt:       "\n\e[33m\e[1mbashly\e[0m > ",
           }
 
           terminal.on('help') { runner.run %w[--help] }

--- a/lib/bashly/commands/shell.rb
+++ b/lib/bashly/commands/shell.rb
@@ -1,0 +1,39 @@
+module Bashly
+  module Commands
+    class Shell < Base
+      summary 'Start an interactive bashly shell'
+      help 'Start an interactive shell where you can run bashly commands'
+
+      usage 'bashly shell'
+      usage 'bashly shell (-h|--help)'
+
+      def run
+        ENV['BASHLY_SHELL'] = '1'
+        terminal.start
+      end
+
+    private
+      def terminal
+        @terminal ||= begin
+          terminal = MisterBin::Terminal.new runner, {
+            autocomplete: autocomplete,
+            show_usage:   true,
+            prompt:       "\n\e[33m\e[1mbashly\e[0m > "
+          }
+
+          terminal.on('help') { runner.run %w[--help] }
+          terminal.on('version') { runner.run %w[--version] }
+          terminal
+        end
+      end
+
+      def runner
+        @runner ||= Bashly::CLI.runner
+      end
+
+      def autocomplete
+        @autocomplete ||= %w[--help] + runner.commands.keys
+      end
+    end
+  end
+end

--- a/spec/approvals/cli/doc/help
+++ b/spec/approvals/cli/doc/help
@@ -1,8 +1,5 @@
 Show bashly reference documentation
 
-This command displays bite-sized help for all the bashly configuration options
-in the terminal.
-
 Usage:
   bashly doc [SEARCH] [--index]
   bashly doc (-h|--help)

--- a/spec/approvals/cli/init/help
+++ b/spec/approvals/cli/init/help
@@ -1,7 +1,6 @@
 Initialize a new workspace
 
-This command will create the source folder, and place a template configuration
-file in it.
+Create the bashly source folder, and place a template configuration file in it
 
 Usage:
   bashly init [--minimal]

--- a/spec/approvals/cli/shell/boot
+++ b/spec/approvals/cli/shell/boot
@@ -7,7 +7,6 @@ Commands:
   generate  Generate the bash script and required files
   add       Add extra features and customization to your script
   doc       Show bashly reference documentation
-  shell     Start an interactive bashly shell
 
 Help: bashly COMMAND --help
 Docs: https://bashly.dannyb.co

--- a/spec/approvals/cli/shell/help
+++ b/spec/approvals/cli/shell/help
@@ -1,0 +1,11 @@
+Start an interactive bashly shell
+
+Start an interactive shell where you can run bashly commands
+
+Usage:
+  bashly shell
+  bashly shell (-h|--help)
+
+Options:
+  -h --help
+    Show this help

--- a/spec/bashly/commands/shell_spec.rb
+++ b/spec/bashly/commands/shell_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Commands::Shell do
+  subject { described_class.new }
+
+  context 'with --help' do
+    it 'shows long usage' do
+      expect { subject.execute %w[terminal --help] }.to output_approval('cli/shell/help')
+    end
+  end
+
+  context 'without parameters' do
+    let(:terminal_double) { instance_double MisterBin::Terminal, start: nil, on: nil }
+
+    it 'runs MisterBin::Terminal' do
+      allow(MisterBin::Terminal).to receive(:new).and_return(terminal_double)
+      expect(terminal_double).to receive(:start)
+      subject.execute %w[shell]
+    end
+  end
+
+  context 'with in-terminal commands' do
+    before do
+      ENV['BASHLY_SHELL'] = nil
+      allow(Readline).to receive(:readline).and_return(*input)
+    end
+
+    context 'with exit command' do
+      let(:input) { ['exit'] }
+
+      it 'starts a terminal and shows CLI usage' do
+        expect { subject.execute %w[shell] }.to output_approval 'cli/shell/boot'
+      end
+    end
+  end
+end


### PR DESCRIPTION
As discussed in #390 - this adds a `bashly shell` command which starts an interactive shell that looks like this:

![236669374-b08bf683-715b-4585-a681-30fc10d90014](https://user-images.githubusercontent.com/2405099/236669795-635b4b73-e1fd-43ad-82da-21f5361e6788.gif)


