### PR TITLE
Simplify YAML loading

### DIFF
--- a/lib/bashly/config.rb
+++ b/lib/bashly/config.rb
@@ -10,7 +10,7 @@ module Bashly
 
     def self.new(config)
       if config.is_a? String
-        YAML.properly_load_file(config).compose
+        YAML.load_file(config).compose
       else
         config
       end

--- a/lib/bashly/extensions/yaml.rb
+++ b/lib/bashly/extensions/yaml.rb
@@ -3,6 +3,6 @@ module YAML
   # This patch is due to https://bugs.ruby-lang.org/issues/17866
   # StackOverflow: https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990
   class << self
-    alias_method :load, :unsafe_load
+    alias load unsafe_load
   end
 end

--- a/lib/bashly/extensions/yaml.rb
+++ b/lib/bashly/extensions/yaml.rb
@@ -1,10 +1,8 @@
 module YAML
-  # This awkward patch is due to https://bugs.ruby-lang.org/issues/17866
-  def self.properly_load_file(path)
-    YAML.load_file path, aliases: true
-  rescue ArgumentError
-    # :nocov:
-    YAML.load_file path
-    # :nocov:
+  # We trust our loaded YAMLs
+  # This patch is due to https://bugs.ruby-lang.org/issues/17866
+  # StackOverflow: https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990
+  class << self
+    alias_method :load, :unsafe_load
   end
 end

--- a/lib/bashly/library_source.rb
+++ b/lib/bashly/library_source.rb
@@ -14,7 +14,7 @@ module Bashly
     end
 
     def config
-      @config ||= YAML.properly_load_file config_path
+      @config ||= YAML.load_file config_path
     end
 
     def libraries

--- a/lib/bashly/message_strings.rb
+++ b/lib/bashly/message_strings.rb
@@ -13,7 +13,7 @@ module Bashly
   private
 
     def values!
-      defaults = YAML.properly_load_file asset('libraries/strings/strings.yml')
+      defaults = YAML.load_file asset('libraries/strings/strings.yml')
       defaults.merge project_strings
     end
 
@@ -23,7 +23,7 @@ module Bashly
 
     def project_strings!
       if File.exist? project_strings_path
-        YAML.properly_load_file project_strings_path
+        YAML.load_file project_strings_path
       else
         {}
       end

--- a/lib/bashly/refinements/compose_refinements.rb
+++ b/lib/bashly/refinements/compose_refinements.rb
@@ -22,7 +22,7 @@ module ComposeRefinements
     end
 
     def safe_load_yaml(path)
-      loaded = YAML.properly_load_file path
+      loaded = YAML.load_file path
       return loaded if loaded.is_a?(Array) || loaded.is_a?(Hash)
 
       raise Bashly::ConfigurationError, "Cannot find a valid YAML in g`#{path}`"

--- a/spec/spec_mixin.rb
+++ b/spec/spec_mixin.rb
@@ -9,7 +9,7 @@ module SpecMixin
 
   def load_fixture(filename)
     @loaded_fixtures ||= {}
-    @loaded_fixtures[filename] ||= YAML.properly_load_file "spec/fixtures/#{filename}.yml"
+    @loaded_fixtures[filename] ||= YAML.load_file "spec/fixtures/#{filename}.yml"
   end
 
   def cp(source, target = 'spec/tmp/')


### PR DESCRIPTION
in preparation for #401

Since Ruby 2.x is no longer supported, we can can simplify the YAML extension.