### PR TITLE
Add ability to render man pages and `bashly add render_mandoc` library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+    - name: Install OS dependencies
+      run: sudo apt-get -y install mandoc
+
     # Rush needed for easy installation of stuff
     - name: Install rush
       run: curl -Ls http://get.dannyb.co/rush/setup | bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+    # Rush needed for easy installation of stuff
+    - name: Install rush
+      run: curl -Ls http://get.dannyb.co/rush/setup | bash
+
+    - name: Connect rush repo
+      run: rush clone dannyben --shallow --default
+
+    - name: Install pandoc
+      run: rush get pandoc
+
     # libyaml needed for Ruby's YAML library
     - name: Install OS dependencies
       run: sudo apt-get -y install libyaml-dev

--- a/lib/bashly/commands/render.rb
+++ b/lib/bashly/commands/render.rb
@@ -1,4 +1,5 @@
 require 'filewatcher'
+require 'date'  # for use by templates
 
 module Bashly
   module Commands
@@ -11,8 +12,11 @@ module Bashly
       param 'SOURCE', <<~HELP
         An ID to an internal templates source, or a path to a custom templates directory.
 
-        Available IDs (note the leading colon):
+        A leading colon (:) denotes an internal ID.
+
+        Available IDs:
         - :markdown - render markdown documents for each command.
+        - :mandoc - render man pages for each command.
       HELP
 
       param 'TARGET', 'Output directory'

--- a/lib/bashly/extensions/string.rb
+++ b/lib/bashly/extensions/string.rb
@@ -8,7 +8,7 @@ class String
   end
 
   def nl2br
-    gsub("\n", "<br>\n")
+    gsub("\n", "  \n")
   end
 
   def indent(offset)

--- a/lib/bashly/libraries/libraries.yml
+++ b/lib/bashly/libraries/libraries.yml
@@ -69,6 +69,20 @@ render_markdown:
 
       m`$ bashly render templates/markdown docs`
 
+render_mandoc:
+  help: Copy the mandoc templates to your project, allowing you to customize the man documentation output.
+  skip_src_check: true
+  files:
+    - source: "render/mandoc/mandoc.gtx"
+      target: "templates/mandoc/mandoc.gtx"
+    - source: "render/mandoc/render.rb"
+      target: "templates/mandoc/render.rb"
+  post_install_message: |
+    Note that this template requires pandoc.
+    Generate your man pages by running:
+
+      m`$ bashly render templates/mandoc docs`
+
 settings:
   help: Copy a sample settings.yml file to your project, allowing you to customize some bashly options.
   skip_src_check: true

--- a/lib/bashly/libraries/render/mandoc/mandoc.gtx
+++ b/lib/bashly/libraries/render/mandoc/mandoc.gtx
@@ -1,0 +1,166 @@
+# Reference: https://linux.die.net/man/5/pandoc_markdown
+
+if version
+> % {{ full_name.tr(' ', '-') }}(1) Version {{ version }} | {{ summary }}
+else
+> % {{ full_name.tr(' ', '-') }}(1) | {{ summary }}
+end
+> % {{ ENV['AUTHORS'] }}
+> % {{ Date.today.strftime "%B %Y" }}
+>
+
+> NAME
+> ==================================================
+> 
+> **{{ full_name }}** - {{ summary }}
+>
+
+> SYNOPSIS
+> ==================================================
+> 
+> {{ usage_string.gsub(/^#{full_name}/, "**#{full_name}**") }}
+>
+
+> DESCRIPTION
+> ==================================================
+> 
+> {{ help.for_markdown }}
+>
+
+if default
+  > - *Default Command*
+end
+if alt.any?
+  > - Alias: **{{ alt.join ', ' }}**
+end
+if extensible
+  if extensible.is_a? String
+    > - Extensible: **{{ extensible }}**
+  else
+    > - *Extensible*
+  end
+end
+>
+
+if commands.any?
+  grouped_commands.each do |group, commands|
+    > {{ group.gsub(/:$/, '').upcase }}
+    > ==================================================
+    >
+    commands.each do |subcommand|
+      > **{{ subcommand.full_name }}**(1)
+      > :    {{ subcommand.summary.for_markdown }}
+      >
+    end
+    >
+  end
+end
+
+if args.any?
+  > ARGUMENTS
+  > ==================================================
+  > 
+  args.each do |arg|
+    > **{{ arg.name.upcase }}**
+    > :    {{ arg.help.for_markdown }}
+    >
+    if arg.required
+      >      - *Required*
+    end
+    if arg.repeatable
+      >      - *Repeatable*
+    end
+    if arg.default
+      >      - Default Value: **{{ arg.default }}**
+    end
+    if arg.allowed
+      >      - Allowed Values: **{{ arg.allowed.join(', ') }}**
+    end
+    >
+  end
+
+  if catch_all.label && catch_all.help
+    > **{{ catch_all.label }}**
+    > :    {{ catch_all.help&.for_markdown }}
+    >
+
+    if catch_all.required?
+      >      - *Required*
+      >
+    end
+  end
+end
+
+if flags.any?
+  > OPTIONS
+  > ==================================================
+  > 
+  flags.each do |flag|
+    > **{{ flag.usage_string }}**
+    > :    {{ flag.help.for_markdown }}
+    >
+
+    if flag.required
+      >      - *Required*
+    end
+    if flag.repeatable
+      >      - *Repeatable*
+    end
+    if flag.default
+      >      - Default Value: **{{ flag.default }}**
+    end
+    if flag.allowed
+      >      - Allowed Values: **{{ flag.allowed.join(', ') }}**
+    end
+    if flag.conflicts
+      >      - Conflicts With: **{{ flag.conflicts.join(', ') }}**
+    end
+    >
+  end
+end
+
+if dependencies.any?
+  > DEPENDENCIES
+  > ==================================================
+  >
+  dependencies.each do |dependency|
+    > **{{ dependency.commands.join ', ' }}**
+    >
+    > :{{ dependency.help&.indent(4)&.for_markdown }}
+    >
+  end
+end
+
+if public_environment_variables.any?
+  > ENVIRONMENT VARIABLES
+  > ==================================================
+  >
+  public_environment_variables.each do |environment_variable|
+    > **{{ environment_variable.name.upcase }}**
+    >
+    > :{{ environment_variable.help.indent(4).for_markdown }}
+    >
+
+    if environment_variable.required
+      >      - *Required*
+    end
+    if environment_variable.default
+      >      - Default Value: **{{ environment_variable.default }}**
+    end
+    >
+  end
+end
+
+if examples
+  > EXAMPLES
+  > ==================================================
+  >
+  > ~~~
+  examples.each do |example|
+    > {{ example.for_markdown }}
+    >
+  end
+  > ~~~
+end
+
+

--- a/lib/bashly/libraries/render/mandoc/render.rb
+++ b/lib/bashly/libraries/render/mandoc/render.rb
@@ -1,0 +1,29 @@
+# render script - mandoc
+
+# Load the GTX template
+template = "#{source}/mandoc.gtx"
+gtx = GTX.load_file template
+
+# Define a reusable code block for rendering a man page for a command
+save_manpage = lambda { |command|
+  mdfile = "#{target}/#{command.full_name.tr(' ', '-')}.md"
+  manfile = "#{target}/#{command.full_name.tr(' ', '-')}.1"
+  save mdfile, gtx.parse(command)
+
+  cmd = %[pandoc -f markdown-smart -s --to man "#{mdfile}" > "#{manfile}"]
+  
+  success = system "#{cmd}"
+  raise "Failed running pandoc\nMake sure the following command succeeds and try again:\n\n  #{cmd}" unless success
+
+  say "g`saved` #{manfile}"
+
+  system %[man "#{manfile}"] if ENV['PREVIEW'] == command.full_name
+}
+
+# Render the main command
+save_manpage.call command
+
+# Render all subcommands
+command.deep_commands.reject(&:private).each do |subcommand|
+  save_manpage.call subcommand
+end

--- a/lib/bashly/libraries/render/markdown/markdown.gtx
+++ b/lib/bashly/libraries/render/markdown/markdown.gtx
@@ -43,8 +43,8 @@ if examples
     > ```bash
     > {{ example }}
     > ```
+    >
   end
-  >
 end
 
 # === Dependencies

--- a/lib/bashly/libraries/render/markdown/render.rb
+++ b/lib/bashly/libraries/render/markdown/render.rb
@@ -1,4 +1,4 @@
-# render script
+# render script - markdown
 
 # Load the GTX template
 template = "#{source}/markdown.gtx"

--- a/spec/approvals/cli/add/list
+++ b/spec/approvals/cli/add/list
@@ -34,6 +34,10 @@ render_markdown
   Copy the markdown templates to your project, allowing you to customize the
   markdown documentation output.
 
+render_mandoc
+  Copy the mandoc templates to your project, allowing you to customize the man
+  documentation output.
+
 settings
   Copy a sample settings.yml file to your project, allowing you to customize
   some bashly options.

--- a/spec/approvals/cli/render/help
+++ b/spec/approvals/cli/render/help
@@ -16,8 +16,11 @@ Parameters:
     An ID to an internal templates source, or a path to a custom templates
     directory.
     
-    Available IDs (note the leading colon):
+    A leading colon (:) denotes an internal ID.
+    
+    Available IDs:
     - :markdown - render markdown documents for each command.
+    - :mandoc - render man pages for each command.
 
   TARGET
     Output directory

--- a/spec/approvals/rendering/mandoc/catch-all-advanced/cli-download.md
+++ b/spec/approvals/rendering/mandoc/catch-all-advanced/cli-download.md
@@ -1,0 +1,52 @@
+% cli-download(1) | Download a file
+% 
+% August 2023
+
+NAME
+==================================================
+
+**cli download** - Download a file
+
+SYNOPSIS
+==================================================
+
+**cli download** SOURCE [TARGET] [OPTIONS] [AWS PARAMS...]
+
+DESCRIPTION
+==================================================
+
+Download a file
+
+- Alias: **d**
+
+ARGUMENTS
+==================================================
+
+**SOURCE**
+:    URL to download from
+
+     - *Required*
+
+**TARGET**
+:    Target filename (default: same as source)
+
+
+**AWS PARAMS...**
+:    Additional arguments or flags for AWS CLI
+
+OPTIONS
+==================================================
+
+**--force, -f**
+:    Overwrite existing files
+
+
+EXAMPLES
+==================================================
+
+~~~
+cli download example.com
+
+cli download example.com ./output -f
+
+~~~

--- a/spec/approvals/rendering/mandoc/catch-all-advanced/cli-upload.md
+++ b/spec/approvals/rendering/mandoc/catch-all-advanced/cli-upload.md
@@ -1,0 +1,21 @@
+% cli-upload(1) | Upload a file
+% 
+% August 2023
+
+NAME
+==================================================
+
+**cli upload** - Upload a file
+
+SYNOPSIS
+==================================================
+
+**cli upload** FILES...
+
+DESCRIPTION
+==================================================
+
+Upload a file
+
+- Alias: **u**
+

--- a/spec/approvals/rendering/mandoc/catch-all-advanced/cli.md
+++ b/spec/approvals/rendering/mandoc/catch-all-advanced/cli.md
@@ -1,0 +1,30 @@
+% cli(1) Version 0.1.0 | Sample application
+% 
+% August 2023
+
+NAME
+==================================================
+
+**cli** - Sample application
+
+SYNOPSIS
+==================================================
+
+**cli** COMMAND
+
+DESCRIPTION
+==================================================
+
+Sample application
+
+
+COMMANDS
+==================================================
+
+**cli download**(1)
+:    Download a file
+
+**cli upload**(1)
+:    Upload a file
+
+

--- a/spec/approvals/rendering/mandoc/catch-all-advanced/stdout
+++ b/spec/approvals/rendering/mandoc/catch-all-advanced/stdout
@@ -1,0 +1,6 @@
+saved spec/tmp/cli.md
+saved spec/tmp/cli.1
+saved spec/tmp/cli-download.md
+saved spec/tmp/cli-download.1
+saved spec/tmp/cli-upload.md
+saved spec/tmp/cli-upload.1

--- a/spec/approvals/rendering/mandoc/dependencies-alt/cli-download.md
+++ b/spec/approvals/rendering/mandoc/dependencies-alt/cli-download.md
@@ -1,0 +1,35 @@
+% cli-download(1) | Download something
+% 
+% August 2023
+
+NAME
+==================================================
+
+**cli download** - Download something
+
+SYNOPSIS
+==================================================
+
+**cli download**
+
+DESCRIPTION
+==================================================
+
+Download something
+
+
+DEPENDENCIES
+==================================================
+
+**git**
+
+:
+
+**ruby**
+
+:    visit $(blue_underlined https://www.ruby-lang.org) to install
+
+**curl, wget**
+
+:    install with $(green sudo apt install curl)
+

--- a/spec/approvals/rendering/mandoc/dependencies-alt/cli.md
+++ b/spec/approvals/rendering/mandoc/dependencies-alt/cli.md
@@ -1,0 +1,27 @@
+% cli(1) Version 0.1.0 | Sample application that requires alternate dependencies
+% 
+% August 2023
+
+NAME
+==================================================
+
+**cli** - Sample application that requires alternate dependencies
+
+SYNOPSIS
+==================================================
+
+**cli** COMMAND
+
+DESCRIPTION
+==================================================
+
+Sample application that requires alternate dependencies
+
+
+COMMANDS
+==================================================
+
+**cli download**(1)
+:    Download something
+
+

--- a/spec/approvals/rendering/mandoc/dependencies-alt/stdout
+++ b/spec/approvals/rendering/mandoc/dependencies-alt/stdout
@@ -1,0 +1,4 @@
+saved spec/tmp/cli.md
+saved spec/tmp/cli.1
+saved spec/tmp/cli-download.md
+saved spec/tmp/cli-download.1

--- a/spec/approvals/rendering/mandoc/docker-like/docker-container-run.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-container-run.md
@@ -1,0 +1,28 @@
+% docker-container-run(1) | Run a container
+% 
+% August 2023
+
+NAME
+==================================================
+
+**docker container run** - Run a container
+
+SYNOPSIS
+==================================================
+
+**docker container run** IMAGE
+
+DESCRIPTION
+==================================================
+
+Run a container
+
+
+ARGUMENTS
+==================================================
+
+**IMAGE**
+:    Image name
+
+     - *Required*
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-container-stop.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-container-stop.md
@@ -1,0 +1,28 @@
+% docker-container-stop(1) | Stop a container
+% 
+% August 2023
+
+NAME
+==================================================
+
+**docker container stop** - Stop a container
+
+SYNOPSIS
+==================================================
+
+**docker container stop** CONTAINER
+
+DESCRIPTION
+==================================================
+
+Stop a container
+
+
+ARGUMENTS
+==================================================
+
+**CONTAINER**
+:    Container name
+
+     - *Required*
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-container.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-container.md
@@ -1,0 +1,31 @@
+% docker-container(1) | Container commands
+% 
+% August 2023
+
+NAME
+==================================================
+
+**docker container** - Container commands
+
+SYNOPSIS
+==================================================
+
+**docker container** COMMAND
+
+DESCRIPTION
+==================================================
+
+Container commands
+
+- Alias: **c***
+
+COMMANDS
+==================================================
+
+**docker container run**(1)
+:    Run a container
+
+**docker container stop**(1)
+:    Stop a container
+
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-image-ls.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-image-ls.md
@@ -1,0 +1,21 @@
+% docker-image-ls(1) | Show all images
+% 
+% August 2023
+
+NAME
+==================================================
+
+**docker image ls** - Show all images
+
+SYNOPSIS
+==================================================
+
+**docker image ls**
+
+DESCRIPTION
+==================================================
+
+Show all images
+
+- Alias: **l**
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-image.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-image.md
@@ -1,0 +1,28 @@
+% docker-image(1) | Image commands
+% 
+% August 2023
+
+NAME
+==================================================
+
+**docker image** - Image commands
+
+SYNOPSIS
+==================================================
+
+**docker image** COMMAND
+
+DESCRIPTION
+==================================================
+
+Image commands
+
+- Alias: **i***
+
+COMMANDS
+==================================================
+
+**docker image ls**(1)
+:    Show all images
+
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-ps.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-ps.md
@@ -1,0 +1,27 @@
+% docker-ps(1) | List containers
+% 
+% August 2023
+
+NAME
+==================================================
+
+**docker ps** - List containers
+
+SYNOPSIS
+==================================================
+
+**docker ps** [OPTIONS]
+
+DESCRIPTION
+==================================================
+
+List containers
+
+
+OPTIONS
+==================================================
+
+**--all, -a**
+:    Show all containers
+
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker.md
@@ -1,0 +1,40 @@
+% docker(1) Version 0.1.0 | Docker example
+% 
+% August 2023
+
+NAME
+==================================================
+
+**docker** - Docker example
+
+SYNOPSIS
+==================================================
+
+**docker** [OPTIONS] COMMAND
+
+DESCRIPTION
+==================================================
+
+Docker example
+
+
+COMMANDS
+==================================================
+
+**docker container**(1)
+:    Container commands
+
+**docker image**(1)
+:    Image commands
+
+**docker ps**(1)
+:    List containers
+
+
+OPTIONS
+==================================================
+
+**--debug, -d**
+:    Enable debug mode
+
+

--- a/spec/approvals/rendering/mandoc/docker-like/stdout
+++ b/spec/approvals/rendering/mandoc/docker-like/stdout
@@ -1,0 +1,14 @@
+saved spec/tmp/docker.md
+saved spec/tmp/docker.1
+saved spec/tmp/docker-container.md
+saved spec/tmp/docker-container.1
+saved spec/tmp/docker-container-run.md
+saved spec/tmp/docker-container-run.1
+saved spec/tmp/docker-container-stop.md
+saved spec/tmp/docker-container-stop.1
+saved spec/tmp/docker-image.md
+saved spec/tmp/docker-image.1
+saved spec/tmp/docker-image-ls.md
+saved spec/tmp/docker-image-ls.1
+saved spec/tmp/docker-ps.md
+saved spec/tmp/docker-ps.1

--- a/spec/approvals/rendering/mandoc/extensible-delegate/mygit-pull.md
+++ b/spec/approvals/rendering/mandoc/extensible-delegate/mygit-pull.md
@@ -1,0 +1,21 @@
+% mygit-pull(1) | Pull from my repository
+% 
+% August 2023
+
+NAME
+==================================================
+
+**mygit pull** - Pull from my repository
+
+SYNOPSIS
+==================================================
+
+**mygit pull**
+
+DESCRIPTION
+==================================================
+
+Pull from my repository
+
+- Alias: **l**
+

--- a/spec/approvals/rendering/mandoc/extensible-delegate/mygit-push.md
+++ b/spec/approvals/rendering/mandoc/extensible-delegate/mygit-push.md
@@ -1,0 +1,21 @@
+% mygit-push(1) | Push to my repository
+% 
+% August 2023
+
+NAME
+==================================================
+
+**mygit push** - Push to my repository
+
+SYNOPSIS
+==================================================
+
+**mygit push**
+
+DESCRIPTION
+==================================================
+
+Push to my repository
+
+- Alias: **p**
+

--- a/spec/approvals/rendering/mandoc/extensible-delegate/mygit.md
+++ b/spec/approvals/rendering/mandoc/extensible-delegate/mygit.md
@@ -1,0 +1,31 @@
+% mygit(1) Version 0.1.0 | Sample application that delegates unknown commands to a different executable
+% 
+% August 2023
+
+NAME
+==================================================
+
+**mygit** - Sample application that delegates unknown commands to a different executable
+
+SYNOPSIS
+==================================================
+
+**mygit** COMMAND
+
+DESCRIPTION
+==================================================
+
+Sample application that delegates unknown commands to a different executable
+
+- Extensible: **git**
+
+COMMANDS
+==================================================
+
+**mygit push**(1)
+:    Push to my repository
+
+**mygit pull**(1)
+:    Pull from my repository
+
+

--- a/spec/approvals/rendering/mandoc/extensible-delegate/stdout
+++ b/spec/approvals/rendering/mandoc/extensible-delegate/stdout
@@ -1,0 +1,6 @@
+saved spec/tmp/mygit.md
+saved spec/tmp/mygit.1
+saved spec/tmp/mygit-push.md
+saved spec/tmp/mygit-push.1
+saved spec/tmp/mygit-pull.md
+saved spec/tmp/mygit-pull.1

--- a/spec/approvals/rendering/mandoc/minimal/download.md
+++ b/spec/approvals/rendering/mandoc/minimal/download.md
@@ -1,0 +1,48 @@
+% download(1) Version 0.1.0 | Sample minimal application without commands
+% 
+% August 2023
+
+NAME
+==================================================
+
+**download** - Sample minimal application without commands
+
+SYNOPSIS
+==================================================
+
+**download** SOURCE [TARGET] [OPTIONS]
+
+DESCRIPTION
+==================================================
+
+Sample minimal application without commands
+
+
+ARGUMENTS
+==================================================
+
+**SOURCE**
+:    URL to download from
+
+     - *Required*
+
+**TARGET**
+:    Target filename (default: same as source)
+
+
+OPTIONS
+==================================================
+
+**--force, -f**
+:    Overwrite existing files
+
+
+EXAMPLES
+==================================================
+
+~~~
+download example.com
+
+download example.com ./output -f
+
+~~~

--- a/spec/approvals/rendering/mandoc/minimal/stdout
+++ b/spec/approvals/rendering/mandoc/minimal/stdout
@@ -1,0 +1,2 @@
+saved spec/tmp/download.md
+saved spec/tmp/download.1

--- a/spec/approvals/rendering/markdown/catch-all-advanced/cli download.md
+++ b/spec/approvals/rendering/markdown/catch-all-advanced/cli download.md
@@ -17,6 +17,7 @@ cli download SOURCE [TARGET] [OPTIONS] [AWS PARAMS...]
 ```bash
 cli download example.com
 ```
+
 ```bash
 cli download example.com ./output -f
 ```

--- a/spec/approvals/rendering/markdown/minimal/index.md
+++ b/spec/approvals/rendering/markdown/minimal/index.md
@@ -17,6 +17,7 @@ download SOURCE [TARGET] [OPTIONS]
 ```bash
 download example.com
 ```
+
 ```bash
 download example.com ./output -f
 ```

--- a/spec/bashly/extensions/string_spec.rb
+++ b/spec/bashly/extensions/string_spec.rb
@@ -10,16 +10,16 @@ describe String do
   describe '#for_markdown' do
     subject { "line one\nline two is <tagged>\n" }
 
-    it 'replaces newline to <br> and escapes < > characters' do
-      expect(subject.for_markdown).to eq "line one<br>\nline two is \\<tagged\\><br>\n"
+    it 'inserts two spaces before newlines and escapes < > characters' do
+      expect(subject.for_markdown).to eq "line one  \nline two is \\<tagged\\>  \n"
     end
   end
 
   describe '#nl2br' do
     subject { "line one\nline two" }
 
-    it 'replaces newline to <br>' do
-      expect(subject.for_markdown).to eq "line one<br>\nline two"
+    it 'inserts two spaces before newlines' do
+      expect(subject.for_markdown).to eq "line one  \nline two"
     end
   end
 

--- a/spec/bashly/integration/rendering_spec.rb
+++ b/spec/bashly/integration/rendering_spec.rb
@@ -22,7 +22,7 @@ describe 'rendering templates' do
         reset_tmp_dir
       end
 
-      it 'runs properly' do
+      it 'renders markdown properly' do
         expect { subject.execute %W[render :markdown #{target}] }
           .to output_approval("rendering/markdown/#{example}/stdout")
 
@@ -31,6 +31,20 @@ describe 'rendering templates' do
           basename = File.basename file
           expect(File.read file).to match_approval("rendering/markdown/#{example}/#{basename}")
             .diff(leeway)
+        end
+      end
+
+      it 'renders mandoc properly' do
+        expect { subject.execute %W[render :mandoc #{target}] }
+          .to output_approval("rendering/mandoc/#{example}/stdout")
+
+        Dir["#{target}/*.md"].each do |file|
+          puts "    => #{file}"
+          basename = File.basename file
+          expect(File.read file).to match_approval("rendering/mandoc/#{example}/#{basename}")
+            .diff(leeway)
+
+          expect(File).to exist("#{target}/#{File.basename(file, '.md')}.1")
         end
       end
     end

--- a/spec/bashly/library_source_spec.rb
+++ b/spec/bashly/library_source_spec.rb
@@ -102,7 +102,7 @@ describe LibrarySource do
       expect(subject.libraries.keys).to match_array %i[
         colors completions completions_script completions_yaml config
         help hooks ini lib settings strings test validations yaml
-        render_markdown
+        render_markdown render_mandoc
       ]
     end
 


### PR DESCRIPTION
Closes #421

- [x] Add mandoc templates - use with `bashly render :mandoc docs`
- [x] Add `bashly add render_mandoc` to allow mandoc template customization.
- [x] Modify `String#nl2br` to use double spaces instead of literal `<br>`, in order to be compatible with pandoc markdown that are intended to be converted to man.
