### PR TITLE
Refactor render command with RenderSource model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       LC_ALL: en_US.UTF-8 
 
     strategy:
-      matrix: { ruby: ['3.0', '3.1', '3.2', head] }
+      matrix: { ruby: ['3.0', '3.1', '3.2'] }
 
     steps:
     - name: Checkout code

--- a/bashly.gemspec
+++ b/bashly.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'gtx', '~> 0.1'
   s.add_dependency 'lp', '~> 0.2'
   s.add_dependency 'mister_bin', '~> 0.7'
+  s.add_dependency 'tty-markdown', '~> 0.7'
 
   # Ruby 3.0 comes with Psych 3.3.0, which does not have the `unsafe_load`
   # ref: https://github.com/ruby/psych/commit/cb50aa8d3fb8be01897becff77b4922b12a0ab4c

--- a/lib/bashly.rb
+++ b/lib/bashly.rb
@@ -16,6 +16,8 @@ module Bashly
   autoload :Library, 'bashly/library'
   autoload :LibrarySource, 'bashly/library_source'
   autoload :MessageStrings, 'bashly/message_strings'
+  autoload :RenderContext, 'bashly/render_context'
+  autoload :RenderSource, 'bashly/render_source'
   autoload :VERSION, 'bashly/version'
 
   autoload :AssetHelper, 'bashly/concerns/asset_helper'

--- a/lib/bashly/libraries/libraries.yml
+++ b/lib/bashly/libraries/libraries.yml
@@ -60,6 +60,8 @@ render_markdown:
   help: Copy the markdown templates to your project, allowing you to customize the markdown documentation output.
   skip_src_check: true
   files:
+    - source: "render/markdown/README.md"
+      target: "templates/markdown/README.md"
     - source: "render/markdown/markdown.gtx"
       target: "templates/markdown/markdown.gtx"
     - source: "render/markdown/render.rb"
@@ -73,6 +75,8 @@ render_mandoc:
   help: Copy the mandoc templates to your project, allowing you to customize the man documentation output.
   skip_src_check: true
   files:
+    - source: "render/mandoc/README.md"
+      target: "templates/mandoc/README.md"
     - source: "render/mandoc/mandoc.gtx"
       target: "templates/mandoc/mandoc.gtx"
     - source: "render/mandoc/render.rb"

--- a/lib/bashly/libraries/render/mandoc/README.md
+++ b/lib/bashly/libraries/render/mandoc/README.md
@@ -1,0 +1,23 @@
+# Render mandoc
+
+Render man pages for your script.
+
+Note that this renderer will render specially formatted markdown documents and
+will then use [pandoc](https://command-not-found.com/pandoc) to convert them.
+
+Setting the environment variable `PREVIEW` to the full command you wish to
+preview, will prompt the renderer to show the output using the `man` command
+after rendering.
+
+## Usage
+
+```bash
+# Generate all man pages to the ./docs directory
+$ bashly render :mandoc docs
+
+# .. and also preview the page for the "cli download" command
+$ PREVIEW="cli download" bashly render :mandoc docs
+
+# .. and also watch for changes
+$ PREVIEW="cli download" bashly render :mandoc docs --watch
+```

--- a/lib/bashly/libraries/render/mandoc/render.rb
+++ b/lib/bashly/libraries/render/mandoc/render.rb
@@ -1,14 +1,5 @@
 # render script - mandoc
-#
-# You may set the environment variable PREVIEW to the full command you wich 
-# to preview while generating. For example:
-#
-#   PREVIEW="cli download" bashly render :mandoc docs --watch
-#
-# Alternatively, view any of the man pages with man:
-#
-#   man docs/cli.1
-#
+require 'gtx'
 
 # Load the GTX template
 template = "#{source}/mandoc.gtx"

--- a/lib/bashly/libraries/render/mandoc/summary.txt
+++ b/lib/bashly/libraries/render/mandoc/summary.txt
@@ -1,0 +1,1 @@
+Render man pages for your script

--- a/lib/bashly/libraries/render/markdown/README.md
+++ b/lib/bashly/libraries/render/markdown/README.md
@@ -1,0 +1,20 @@
+# Render markdown
+
+Render markdown documents for your script.
+
+## Usage
+
+```bash
+# Generate all documents to the ./docs directory
+$ bashly render :markdown docs
+```
+
+## Viewing your markdown documents
+
+In order to preview your markdown files, you can use the
+[Madness markdown server](https://madness.dannyb.co/):
+
+```bash
+$ gem install madness
+$ madness server docs
+```

--- a/lib/bashly/libraries/render/markdown/render.rb
+++ b/lib/bashly/libraries/render/markdown/render.rb
@@ -1,11 +1,5 @@
 # render script - markdown
-#
-# In order to preview your markdown files, you can use the madness markdown
-# server <https://madness.dannyb.co/>:
-#
-#   $ gem install madness
-#   $ madness server docs
-#
+require 'gtx'
 
 # Load the GTX template
 template = "#{source}/markdown.gtx"

--- a/lib/bashly/libraries/render/markdown/summary.txt
+++ b/lib/bashly/libraries/render/markdown/summary.txt
@@ -1,0 +1,1 @@
+Render markdown documents for your script

--- a/lib/bashly/render_context.rb
+++ b/lib/bashly/render_context.rb
@@ -1,0 +1,28 @@
+require 'date'    # for use by template render scripts
+require 'colsole'
+
+module Bashly
+  class RenderContext
+    include Colsole
+
+    attr_reader :source, :target
+
+    def initialize(source, target)
+      @source = source
+      @target = target
+    end
+
+    def config
+      @config ||= Config.new Settings.config_path
+    end
+
+    def command
+      @command ||= Script::Command.new config
+    end
+
+    def save(filename, content)
+      File.deep_write filename, content
+      say "g`saved` #{filename}"
+    end
+  end
+end

--- a/lib/bashly/render_source.rb
+++ b/lib/bashly/render_source.rb
@@ -1,0 +1,70 @@
+module Bashly
+  class RenderSource
+    attr_reader :selector
+
+    class << self
+      include AssetHelper
+
+      def internal
+        @internal ||= internal_dirs.to_h do |dir|
+          selector = File.basename(dir).to_sym
+          [selector, new(selector)]
+        end
+      end
+
+      def internal_dirs
+        @internal_dirs ||= Dir["#{internal_root}/*"].select { |x| File.directory? x }
+      end
+
+      def internal_root
+        asset('libraries/render')
+      end
+    end
+
+    def initialize(selector)
+      @selector = selector
+    end
+
+    def render(target)
+      RenderContext.new(path, target).instance_eval render_script
+    end
+
+    def internal?
+      selector.is_a? Symbol
+    end
+
+    def path
+      internal? ? "#{internal_root}/#{selector}" : selector
+    end
+
+    def exist?
+      Dir.exist? path
+    end
+
+    def summary
+      File.readlines(summary_file)[0].chomp
+    end
+
+    def readme
+      File.read readme_file if File.exist? readme_file
+    end
+
+  private
+
+    def render_script
+      @render_script ||= File.read "#{path}/render.rb"
+    end
+
+    def internal_root
+      self.class.internal_root
+    end
+
+    def summary_file
+      "#{path}/summary.txt"
+    end
+
+    def readme_file
+      "#{path}/README.md"
+    end
+  end
+end

--- a/spec/approvals/cli/render/about-markdown
+++ b/spec/approvals/cli/render/about-markdown
@@ -1,0 +1,17 @@
+Render markdown
+
+Render markdown documents for your script.
+
+  Usage
+
+  # Generate all documents to the ./docs directory
+  $ bashly render :markdown docs
+  
+  Viewing your markdown documents
+
+  In order to preview your markdown files, you can use the
+  Madness markdown server » https://madness.dannyb.co/:
+
+  $ gem install madness
+  $ madness server docs
+  

--- a/spec/approvals/cli/render/help
+++ b/spec/approvals/cli/render/help
@@ -2,11 +2,19 @@ Render the bashly data structure using cutsom templates
 
 Usage:
   bashly render SOURCE TARGET [options]
+  bashly render SOURCE --about
+  bashly render --list
   bashly render (-h|--help)
 
 Options:
   -w --watch
     Watch bashly.yml and the templates source for changes and render on change
+
+  -l --list
+    Show list of built-in templates
+
+  -a --about
+    Show information about a given templates source
 
   -h --help
     Show this help
@@ -16,15 +24,13 @@ Parameters:
     An ID to an internal templates source, or a path to a custom templates
     directory.
     
-    A leading colon (:) denotes an internal ID.
-    
-    Available IDs:
-    - :markdown - render markdown documents for each command.
-    - :mandoc - render man pages for each command.
+    A leading colon (:) denotes an internal ID (see `--list`).
 
   TARGET
     Output directory
 
 Examples:
+  bashly render --list
+  bashly render :markdown --about
   bashly render :markdown docs --watch
   bashly render /path/to/templates ./out_path

--- a/spec/approvals/cli/render/list
+++ b/spec/approvals/cli/render/list
@@ -1,0 +1,2 @@
+:mandoc      Render man pages for your script
+:markdown    Render markdown documents for your script

--- a/spec/approvals/cli/render/source-not-found
+++ b/spec/approvals/cli/render/source-not-found
@@ -1,2 +1,1 @@
-#<RuntimeError: Invalid source.
-Directory not found: no-templates-4U>
+#<RuntimeError: Invalid render source: no-templates-4U>

--- a/spec/bashly/commands/render_spec.rb
+++ b/spec/bashly/commands/render_spec.rb
@@ -21,7 +21,7 @@ describe Commands::Render do
   context 'with --about' do
     it 'shows the readme of the template source' do
       expect { subject.execute %w[render :markdown --about] }
-        .to output_approval('cli/render/about-markdown').diff(5)
+        .to output_approval('cli/render/about-markdown').diff(8)
     end
   end
 

--- a/spec/bashly/commands/render_spec.rb
+++ b/spec/bashly/commands/render_spec.rb
@@ -21,7 +21,7 @@ describe Commands::Render do
   context 'with --about' do
     it 'shows the readme of the template source' do
       expect { subject.execute %w[render :markdown --about] }
-        .to output_approval('cli/render/about-markdown')
+        .to output_approval('cli/render/about-markdown').diff(5)
     end
   end
 

--- a/spec/bashly/commands/render_spec.rb
+++ b/spec/bashly/commands/render_spec.rb
@@ -11,6 +11,20 @@ describe Commands::Render do
     end
   end
 
+  context 'with --list' do
+    it 'shows the list of internal render sources' do
+      expect { subject.execute %w[render --list] }
+        .to output_approval('cli/render/list')
+    end
+  end
+
+  context 'with --about' do
+    it 'shows the readme of the template source' do
+      expect { subject.execute %w[render :markdown --about] }
+        .to output_approval('cli/render/about-markdown')
+    end
+  end
+
   context 'with :markdown source' do
     before { reset_tmp_dir init: true }
 
@@ -50,22 +64,6 @@ describe Commands::Render do
 
       expect { subject.execute %W[render :markdown #{target} --watch] }
         .to output_approval('cli/render/watch')
-    end
-
-    context 'when ConfigurationError is raised during watch' do
-      let(:watcher_double) { instance_double Filewatcher, watch: nil }
-
-      it 'shows the error gracefully and continues to watch' do
-        allow(Filewatcher).to receive(:new).and_return(watcher_double)
-        allow(watcher_double).to receive(:watch) do |&block|
-          bashly_config['invalid_option'] = 'error this'
-          File.write bashly_config_path, bashly_config.to_yaml
-          block.call
-        end
-
-        expect { subject.execute %W[render :markdown #{target} --watch] }
-          .to output_approval('cli/render/watch-stderr').to_stderr
-      end
     end
   end
 end

--- a/spec/bashly/render_source_spec.rb
+++ b/spec/bashly/render_source_spec.rb
@@ -1,0 +1,56 @@
+describe RenderSource do
+  subject { described_class.new selector }
+
+  let(:selector) { :markdown }
+  let(:path_to_source) { 'lib/bashly/libraries/render/markdown' }
+
+  describe '#internal?' do
+    context 'with an internal source' do
+      it 'returns true' do
+        expect(subject).to be_internal
+      end
+    end
+
+    context 'with an external source' do
+      let(:selector) { path_to_source }
+
+      it 'returns false' do
+        expect(subject).not_to be_internal
+      end
+    end
+  end
+
+  describe '#path' do
+    it "returns the path to the source's root directory" do
+      expect(subject.path).to end_with path_to_source
+    end
+  end
+
+  describe '#exist?' do
+    context 'when the path exists' do
+      it 'returns true' do
+        expect(subject).to exist
+      end
+    end
+
+    context 'when the path does not exist' do
+      let(:selector) { 'no-such-source' }
+
+      it 'returns false' do
+        expect(subject).not_to exist
+      end
+    end
+  end
+
+  describe '#summary' do
+    it 'returns the first line of the summary file' do
+      expect(subject.summary).to eq File.readlines("#{path_to_source}/summary.txt")[0].chomp
+    end
+  end
+
+  describe '#readme' do
+    it 'returns the content of the readme file' do
+      expect(subject.readme).to eq File.read("#{path_to_source}/README.md")
+    end
+  end
+end


### PR DESCRIPTION
The `bashly render` command now delegates the work to `RenderSource`.

Notable changes:

1. New `RenderSource` model to represent either an external or internal template source.
2. New `RenderContext` model that will host and run the `render.rb` scripts for the templates in isolation.
3. New `bashly render --list` command that shows the built-in template sources.
4. New `bashly render SOURCE --about` that shows the README from the template source in a nice colorful terminal output.
5. Templates sources should include `summary.txt` file now (used by `bashly render --list`).
6. Templates sources should include `README.md` file now (used by `bashly render SOURCE --about`).
