### PR TITLE
Allow arbitrary (`x-anything`) keys in bashly.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,5 +116,5 @@ jobs:
     - name: Generate all subjects
       run: bundle exec run examples regen
 
-    - name: Run bashly schema tests
+    - name: Run schema tests
       run: bundle exec run schema all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,4 @@ jobs:
       run: bundle exec run examples regen
 
     - name: Run bashly schema tests
-      run: bundle exec run schema examples
-
-    - name: Run settings schema tests
-      run: bundle exec run schema settings
-
-    - name: Run strings schema tests
-      run: bundle exec run schema strings
+      run: bundle exec run schema all

--- a/lib/bashly/concerns/validation_helpers.rb
+++ b/lib/bashly/concerns/validation_helpers.rb
@@ -41,6 +41,7 @@ module Bashly
       return unless keys
 
       invalid_keys = value.keys.map(&:to_sym) - keys
+      invalid_keys.reject! { |key| key.start_with? 'x-' }
       assert invalid_keys.empty?, "#{key} contains invalid options: #{invalid_keys.join ', '}"
     end
 

--- a/schemas/bashly.json
+++ b/schemas/bashly.json
@@ -1,6 +1,17 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "definitions": {
+        "custom-properties": {
+            "patternProperties": {
+                "^x-.": {
+                    "title": "custom property",
+                    "description": "A custom property",
+                    "examples": [
+                        "hello"
+                    ]
+                }
+            }
+        },
         "argument": {
             "title": "argument",
             "description": "A positional argument of the current script or sub-command\nhttps://bashly.dannyb.co/configuration/argument/",
@@ -74,8 +85,8 @@
                     ]
                 }
             },
-            "additionalProperties": false,
-            "patternProperties": { "^x-.": {} }
+            "$ref": "#/definitions/custom-properties",
+            "additionalProperties": false
         },
         "flag": {
             "title": "flag",
@@ -210,8 +221,8 @@
                     ]
                 }
             },
-            "additionalProperties": false,
-            "patternProperties": { "^x-.": {} }
+            "$ref": "#/definitions/custom-properties",
+            "additionalProperties": false
         },
         "name-property": {
             "title": "name",
@@ -407,8 +418,8 @@
                             "$ref": "#/definitions/environment-variables-required-property"
                         }
                     },
-                    "additionalProperties": false,
-                    "patternProperties": { "^x-.": {} }
+                    "$ref": "#/definitions/custom-properties",
+                    "additionalProperties": false
                 },
                 "else": {
                     "properties": {
@@ -425,8 +436,8 @@
                             "$ref": "#/definitions/environment-variables-required-property"
                         }
                     },
-                    "additionalProperties": false,
-                    "patternProperties": { "^x-.": {} }
+                    "$ref": "#/definitions/custom-properties",
+                    "additionalProperties": false
                 }
             }
         },
@@ -783,8 +794,8 @@
                     "$ref": "#/definitions/sub-command-import-property"
                 }
             },
-            "additionalProperties": false,
-            "patternProperties": { "^x-.": {} }
+            "$ref": "#/definitions/custom-properties",
+            "additionalProperties": false
         }
     },
     "title": "cli",
@@ -840,6 +851,6 @@
             "$ref": "#/definitions/function-property"
         }
     },
-    "additionalProperties": false,
-    "patternProperties": { "^x-.": {} }
+    "$ref": "#/definitions/custom-properties",
+    "additionalProperties": false
 }

--- a/schemas/bashly.json
+++ b/schemas/bashly.json
@@ -75,7 +75,7 @@
                 }
             },
             "additionalProperties": false,
-            "patternProperties": { "^x-": {} }
+            "patternProperties": { "^x-.": {} }
         },
         "flag": {
             "title": "flag",
@@ -211,7 +211,7 @@
                 }
             },
             "additionalProperties": false,
-            "patternProperties": { "^x-": {} }
+            "patternProperties": { "^x-.": {} }
         },
         "name-property": {
             "title": "name",
@@ -408,7 +408,7 @@
                         }
                     },
                     "additionalProperties": false,
-                    "patternProperties": { "^x-": {} }
+                    "patternProperties": { "^x-.": {} }
                 },
                 "else": {
                     "properties": {
@@ -426,7 +426,7 @@
                         }
                     },
                     "additionalProperties": false,
-                    "patternProperties": { "^x-": {} }
+                    "patternProperties": { "^x-.": {} }
                 }
             }
         },
@@ -784,7 +784,7 @@
                 }
             },
             "additionalProperties": false,
-            "patternProperties": { "^x-": {} }
+            "patternProperties": { "^x-.": {} }
         }
     },
     "title": "cli",
@@ -841,5 +841,5 @@
         }
     },
     "additionalProperties": false,
-    "patternProperties": { "^x-": {} }
+    "patternProperties": { "^x-.": {} }
 }

--- a/schemas/bashly.json
+++ b/schemas/bashly.json
@@ -5,7 +5,7 @@
             "patternProperties": {
                 "^x-.": {
                     "title": "custom property",
-                    "description": "A custom property",
+                    "description": "A custom property of any type",
                     "examples": [
                         "This command shows the status of all `images`, `containers` and `volumes`. Use with `--verbose` to see deleted containers."
                     ]

--- a/schemas/bashly.json
+++ b/schemas/bashly.json
@@ -7,7 +7,7 @@
                     "title": "custom property",
                     "description": "A custom property",
                     "examples": [
-                        "hello"
+                        "This command shows the status of all `images`, `containers` and `volumes`. Use with `--verbose` to see deleted containers."
                     ]
                 }
             }

--- a/schemas/bashly.json
+++ b/schemas/bashly.json
@@ -74,7 +74,8 @@
                     ]
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "patternProperties": { "^x-": {} }
         },
         "flag": {
             "title": "flag",
@@ -209,7 +210,8 @@
                     ]
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "patternProperties": { "^x-": {} }
         },
         "name-property": {
             "title": "name",
@@ -405,7 +407,8 @@
                             "$ref": "#/definitions/environment-variables-required-property"
                         }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "patternProperties": { "^x-": {} }
                 },
                 "else": {
                     "properties": {
@@ -422,7 +425,8 @@
                             "$ref": "#/definitions/environment-variables-required-property"
                         }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "patternProperties": { "^x-": {} }
                 }
             }
         },
@@ -779,7 +783,8 @@
                     "$ref": "#/definitions/sub-command-import-property"
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "patternProperties": { "^x-": {} }
         }
     },
     "title": "cli",
@@ -835,5 +840,6 @@
             "$ref": "#/definitions/function-property"
         }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": { "^x-": {} }
 }

--- a/spec/fixtures/script/x-arbitrary.yml
+++ b/spec/fixtures/script/x-arbitrary.yml
@@ -1,0 +1,29 @@
+name: docker
+x-string: hello
+x-hash: { key: value }
+x-array: [1, 2]
+x-int: 1
+x-float: 1.2
+x-boolean: yes
+x-nil: ~
+
+environment_variables:
+- name: rush_config
+  x-any: hello
+
+commands:
+- name: status
+  x-any: hello
+
+  args:
+  - name: repo
+    x-any: hello
+
+  flags:
+  - long: --purge
+    x-any: hello
+
+- name: images
+  commands:
+  - name: ls
+    x-any: hello

--- a/support/runfile/schema.runfile
+++ b/support/runfile/schema.runfile
@@ -1,30 +1,57 @@
 summary 'Run json-schema checks on all examples'
 
-help   'Test the bashly schema against all examples'
-action :examples do
-  Example.all.each do |example|
-    file = example.yaml_path
-    command = "check-jsonschema --schemafile schemas/bashly.json #{file}"
-    say "\n$ check-jsonschema bb`#{example.dir}`"
+help 'Run all the actions in this runfile'
+action :all do
+  check_examples
+  check_settings
+  check_strings
+  check_arbitrary
+end
+
+help 'Test the bashly schema against all examples'
+action(:examples) { check_examples }
+
+help 'Test the settings schema against the default settings template'
+action(:settings) { check_settings }
+
+help 'Test the strings schema against the default strings template'
+action(:strings) { check_strings }
+
+help 'Test the bashly schema against a bashly configuration that includes arbitrary (x-) keys'
+action(:arbitrary) { check_arbitrary }
+
+helpers do
+  def check_examples
+    say "\ngub`Examples`"
+    Example.all.each do |example|
+      file = example.yaml_path
+      schema_check file
+    end
+  end
+
+  def check_settings
+    say "\ngub`Settings`"
+    file = 'lib/bashly/libraries/settings/settings.yml'
+    schema_check file, :settings
+  end
+
+  def check_strings
+    say "\ngub`Strings`"
+    file = 'lib/bashly/libraries/strings/strings.yml'
+    schema_check file, :strings
+  end
+
+  def check_arbitrary
+    say "\ngub`Arbitrary`"
+    file = 'spec/fixtures/script/x-arbitrary.yml'
+    schema_check file
+  end
+
+  def schema_check(file, schema = 'bashly')
+    command = "check-jsonschema --schemafile schemas/#{schema}.json #{file}"
+    say "\nnb`$ check-jsonschema` [m`#{schema}`] bb`#{file}`"
     success = system command
+    
     abort 'Failed' unless success
   end
-end
-
-help   'Test the settings schema against the default settings template'
-action :settings do
-  file = 'lib/bashly/libraries/settings/settings.yml'
-  command = "check-jsonschema --schemafile schemas/settings.json #{file}"
-  say "\n$ check-jsonschema bb`#{file}`"
-  success = system command
-  abort 'Failed' unless success
-end
-
-help   'Test the strings schema against the default strings template'
-action :strings do
-  file = 'lib/bashly/libraries/strings/strings.yml'
-  command = "check-jsonschema --schemafile schemas/strings.json #{file}"
-  say "\n$ check-jsonschema bb`#{file}`"
-  success = system command
-  abort 'Failed' unless success
 end


### PR DESCRIPTION
cc #426

- [x] The `ConfigValidator` now ignores hash keys that start with `x-`
- [x] The JSON schema now allows `x-` keys in all the primary objects.

@EmilySeville7cfg - can you verify this is the best way to allow `x-anything`? I only added it in several places, assuming there is no way to allow it *everywhere*.