### PR TITLE
Refactor mandoc template to use `x_mandoc_footer` and `x_mandoc_authors`

### DIFF
--- a/lib/bashly/libraries/render/mandoc/README.md
+++ b/lib/bashly/libraries/render/mandoc/README.md
@@ -5,24 +5,52 @@ Render man pages for your script.
 Note that this renderer will render specially formatted markdown documents and
 will then use [pandoc](https://command-not-found.com/pandoc) to convert them.
 
-Setting the environment variable `PREVIEW` to the full command you wish to
-preview, will prompt the renderer to show the output using the `man` command
-after rendering.
-
 ## Usage
 
 ```bash
 # Generate all man pages to the ./docs directory
 $ bashly render :mandoc docs
+```
 
-# .. and also preview the page for the "cli download" command
+## Special template features
+
+### Preview
+
+Setting the environment variable `PREVIEW` to the full command you wish
+to preview, will prompt the renderer to show the output using the `man`
+command after rendering.
+
+```bash
+# Preview the page for the "cli download" command
 $ PREVIEW="cli download" bashly render :mandoc docs
 
-# .. and also watch for changes
+# .. and also watch for changes (after existing the man preview)
 $ PREVIEW="cli download" bashly render :mandoc docs --watch
 ```
 
-## Appending a footer
+### Footer
 
-In case you wish to append additional sections to your generated man pages,
-you can place a file named `_footer.md` in your target directory.
+You can add additional sections to any of the generated man pages, by
+adding a property named `x_mandoc_footer` to any of your commands in
+your `bashly.yml`.
+
+This field should contain a markdown string, for example:
+
+```yaml
+x_mandoc_footer: |-
+  # ISSUE TRACKER
+
+  Report issues at <https://github.com/lanalang/smallville>
+```
+
+### Authors
+
+You can specify an authors string that will be added to the man page,
+by adding a property named `x_mandoc_authors` to any of your commands
+in your `bashly.yml`.
+
+For example:
+
+```yaml
+x_mandoc_authors: Lana Lang
+```

--- a/lib/bashly/libraries/render/mandoc/mandoc.gtx
+++ b/lib/bashly/libraries/render/mandoc/mandoc.gtx
@@ -5,7 +5,7 @@ if version
 else
 > % {{ full_name.to_hyphen }}(1) | {{ summary }}
 end
-> % {{ ENV['AUTHORS'] }}
+> % {{ x_mandoc_authors }}
 > % {{ Date.today.strftime "%B %Y" }}
 >
 
@@ -177,4 +177,5 @@ if public_commands.any?
   >
 end
 
+= x_mandoc_footer
 >

--- a/lib/bashly/libraries/render/mandoc/render.rb
+++ b/lib/bashly/libraries/render/mandoc/render.rb
@@ -11,12 +11,6 @@ save_manpage = lambda { |command|
   manfile = "#{target}/#{command.full_name.tr(' ', '-')}.1"
   save mdfile, gtx.parse(command)
 
-  # Append the footer file if it exists
-  footer_file = "#{target}/_footer.md"
-  if File.exist? footer_file
-    File.append mdfile, File.read(footer_file)
-  end
-
   # The pandoc command that creates a manpage from markdown
   cmd = %[pandoc -f markdown-smart -s --to man "#{mdfile}" > "#{manfile}"]
   success = system cmd

--- a/spec/approvals/rendering/mandoc/catch-all-advanced/cli-download.md
+++ b/spec/approvals/rendering/mandoc/catch-all-advanced/cli-download.md
@@ -52,3 +52,4 @@ cli download example.com ./output -f
 
 ~~~
 
+

--- a/spec/approvals/rendering/mandoc/catch-all-advanced/cli-upload.md
+++ b/spec/approvals/rendering/mandoc/catch-all-advanced/cli-upload.md
@@ -19,3 +19,4 @@ Upload a file
 
 - Alias: **u**
 
+

--- a/spec/approvals/rendering/mandoc/catch-all-advanced/cli.md
+++ b/spec/approvals/rendering/mandoc/catch-all-advanced/cli.md
@@ -33,3 +33,4 @@ SEE ALSO
 
 **cli-download**(1), **cli-upload**(1)
 
+

--- a/spec/approvals/rendering/mandoc/dependencies-alt/cli-download.md
+++ b/spec/approvals/rendering/mandoc/dependencies-alt/cli-download.md
@@ -31,3 +31,4 @@ DEPENDENCIES
 :    install with $(green sudo apt install curl)
 
 
+

--- a/spec/approvals/rendering/mandoc/dependencies-alt/cli.md
+++ b/spec/approvals/rendering/mandoc/dependencies-alt/cli.md
@@ -30,3 +30,4 @@ SEE ALSO
 
 **cli-download**(1)
 
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-container-run.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-container-run.md
@@ -26,3 +26,4 @@ ARGUMENTS
 
      - *Required*
 
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-container-stop.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-container-stop.md
@@ -26,3 +26,4 @@ ARGUMENTS
 
      - *Required*
 
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-container.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-container.md
@@ -34,3 +34,4 @@ SEE ALSO
 
 **docker-container-run**(1), **docker-container-stop**(1)
 
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-image-ls.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-image-ls.md
@@ -19,3 +19,4 @@ Show all images
 
 - Alias: **l**
 
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-image.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-image.md
@@ -31,3 +31,4 @@ SEE ALSO
 
 **docker-image-ls**(1)
 
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker-ps.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker-ps.md
@@ -25,3 +25,4 @@ OPTIONS
 :    Show all containers
 
 
+

--- a/spec/approvals/rendering/mandoc/docker-like/docker.md
+++ b/spec/approvals/rendering/mandoc/docker-like/docker.md
@@ -43,3 +43,4 @@ SEE ALSO
 
 **docker-container**(1), **docker-image**(1), **docker-ps**(1)
 
+

--- a/spec/approvals/rendering/mandoc/extensible-delegate/mygit-pull.md
+++ b/spec/approvals/rendering/mandoc/extensible-delegate/mygit-pull.md
@@ -19,3 +19,4 @@ Pull from my repository
 
 - Alias: **l**
 
+

--- a/spec/approvals/rendering/mandoc/extensible-delegate/mygit-push.md
+++ b/spec/approvals/rendering/mandoc/extensible-delegate/mygit-push.md
@@ -19,3 +19,4 @@ Push to my repository
 
 - Alias: **p**
 
+

--- a/spec/approvals/rendering/mandoc/extensible-delegate/mygit.md
+++ b/spec/approvals/rendering/mandoc/extensible-delegate/mygit.md
@@ -34,3 +34,4 @@ SEE ALSO
 
 **mygit-push**(1), **mygit-pull**(1)
 
+

--- a/spec/approvals/rendering/mandoc/minimal/download.md
+++ b/spec/approvals/rendering/mandoc/minimal/download.md
@@ -47,3 +47,4 @@ download example.com ./output -f
 
 ~~~
 
+


### PR DESCRIPTION
Thanks to #426 and #428 - we can now use custom properties for custom renderes.

This PR updates the mandoc renderer to consider `x_mandoc_authors` and `x_mandoc_footer` on any command, and include it in the rendered man page.