### PR TITLE
Integrate with unofficial draft-07 schema for better hints and validation

### DIFF
--- a/schemas/settings.json
+++ b/schemas/settings.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json",
     "definitions": {
         "color": {
             "oneOf": [

--- a/schemas/strings.json
+++ b/schemas/strings.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json",
     "title": "strings",
     "description": "Strings of the current application\nhttps://bashly.dannyb.co/advanced/strings/#custom-strings",
     "type": "object",


### PR DESCRIPTION

Why to make this change is explained [here](https://github.com/SchemaStore/schemastore/pull/3260). Note that this schema may produce false positives like when `$ref` is used and `title`/`description`/`type` are not stated directly, but those cases can be safely ignored. It's better to get more errors when most of them are right, than get less errors and miss some real issues. :) This schema is designed to work the best with VS Code as tested just through YAML Red Hat extension.

![image](https://github.com/DannyBen/bashly/assets/42812113/5a247b1c-0e48-42f9-94ba-9faf24930594)