### PR TITLE
Fix missing tmpdir library in `bashly add --source`

### DIFF
--- a/lib/bashly/library_source.rb
+++ b/lib/bashly/library_source.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'tmpdir'
 
 module Bashly
   class LibrarySource


### PR DESCRIPTION
cc #440