### PR TITLE
Validate libraries.yml

### DIFF
--- a/examples/render-mandoc/docs/download.1
+++ b/examples/render-mandoc/docs/download.1
@@ -14,7 +14,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "download" "1" "September 2023" "Version 0.1.0" "Sample application"
+.TH "download" "1" "October 2023" "Version 0.1.0" "Sample application"
 .hy
 .SH NAME
 .PP

--- a/examples/render-mandoc/docs/download.md
+++ b/examples/render-mandoc/docs/download.md
@@ -1,6 +1,6 @@
 % download(1) Version 0.1.0 | Sample application
 % Lana Lang
-% September 2023
+% October 2023
 
 NAME
 ==================================================

--- a/lib/bashly.rb
+++ b/lib/bashly.rb
@@ -15,6 +15,7 @@ module Bashly
   autoload :ConfigValidator, 'bashly/config_validator'
   autoload :Library, 'bashly/library'
   autoload :LibrarySource, 'bashly/library_source'
+  autoload :LibrarySourceConfig, 'bashly/library_source_config'
   autoload :MessageStrings, 'bashly/message_strings'
   autoload :RenderContext, 'bashly/render_context'
   autoload :RenderSource, 'bashly/render_source'

--- a/lib/bashly/library_source.rb
+++ b/lib/bashly/library_source.rb
@@ -15,7 +15,7 @@ module Bashly
     end
 
     def config
-      @config ||= YAML.load_file config_path
+      @config ||= LibrarySourceConfig.new(config_path).validated_data
     end
 
     def libraries

--- a/lib/bashly/library_source_config.rb
+++ b/lib/bashly/library_source_config.rb
@@ -1,0 +1,48 @@
+module Bashly
+  class LibrarySourceConfig
+    include ValidationHelpers
+
+    attr_reader :path
+
+    def initialize(path)
+      @path = path
+    end
+
+    def data
+      @data ||= YAML.load_file path
+    end
+
+    def validated_data
+      validate
+      data
+    end
+
+    def validate
+      assert_root path, data
+    end
+
+  private
+
+    def assert_root(path, value)
+      assert_hash path, value
+      data.each { |id, spec| assert_lib "[#{path}] #{id}", spec }
+    end
+
+    def assert_lib(key, value)
+      assert_string "#{key}.help", value['help']
+      
+      assert_optional_string "#{key}.usage", value['usage']
+      assert_optional_string "#{key}.handler", value['handler']
+      assert_optional_string "#{key}.post_install_message", value['post_install_message']
+
+      return if value['handler']
+
+      assert_array "#{key}.files", value['files'], of: :filespec
+    end
+
+    def assert_filespec(key, value)
+      assert_string "#{key}.source", value['source']
+      assert_string "#{key}.target", value['target']
+    end
+  end
+end

--- a/lib/bashly/library_source_config.rb
+++ b/lib/bashly/library_source_config.rb
@@ -30,7 +30,7 @@ module Bashly
 
     def assert_lib(key, value)
       assert_string "#{key}.help", value['help']
-      
+
       assert_optional_string "#{key}.usage", value['usage']
       assert_optional_string "#{key}.handler", value['handler']
       assert_optional_string "#{key}.post_install_message", value['post_install_message']

--- a/spec/approvals/examples/render-mandoc
+++ b/spec/approvals/examples/render-mandoc
@@ -44,4 +44,4 @@ ISSUE TRACKER
 AUTHORS
        Lana Lang.
 
-Version 0.1.0                   September 2023                     download(1)
+Version 0.1.0                    October 2023                      download(1)

--- a/spec/approvals/libraries/render/mandoc/render-1-download.1
+++ b/spec/approvals/libraries/render/mandoc/render-1-download.1
@@ -29,4 +29,4 @@ EXAMPLES
               download example.com ./output -f
 
 
-Version 0.1.0                   MONTH YEAR                     download(1)
+Version 0.1.0                    MONTH YEAR                      download(1)

--- a/spec/approvals/libraries_validation/files_array
+++ b/spec/approvals/libraries_validation/files_array
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: [spec/fixtures/libraries/errors/files_array.yml] database.files must be an array>

--- a/spec/approvals/libraries_validation/files_source
+++ b/spec/approvals/libraries_validation/files_source
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: [spec/fixtures/libraries/errors/files_source.yml] database.files[0].source must be a string>

--- a/spec/approvals/libraries_validation/files_target
+++ b/spec/approvals/libraries_validation/files_target
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: [spec/fixtures/libraries/errors/files_target.yml] database.files[0].target must be a string>

--- a/spec/approvals/libraries_validation/handler_string
+++ b/spec/approvals/libraries_validation/handler_string
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: [spec/fixtures/libraries/errors/handler_string.yml] database.handler must be a string>

--- a/spec/approvals/libraries_validation/help_string
+++ b/spec/approvals/libraries_validation/help_string
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: [spec/fixtures/libraries/errors/help_string.yml] database.help must be a string>

--- a/spec/approvals/libraries_validation/message_string
+++ b/spec/approvals/libraries_validation/message_string
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: [spec/fixtures/libraries/errors/message_string.yml] database.post_install_message must be a string>

--- a/spec/approvals/libraries_validation/root_hash
+++ b/spec/approvals/libraries_validation/root_hash
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: spec/fixtures/libraries/errors/root_hash.yml must be a hash>

--- a/spec/approvals/libraries_validation/usage_string
+++ b/spec/approvals/libraries_validation/usage_string
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: [spec/fixtures/libraries/errors/usage_string.yml] database.usage must be a string>

--- a/spec/bashly/config_validator_spec.rb
+++ b/spec/bashly/config_validator_spec.rb
@@ -1,14 +1,13 @@
 describe ConfigValidator do
   fixtures = load_fixture 'script/validations'
-  subject { described_class.new options }
 
   describe '#validate' do
     fixtures.each do |fixture, options|
-      context "with :#{fixture}" do
-        let(:options) { options }
+      validator = described_class.new options
 
+      context "with :#{fixture}" do
         it 'raises an error' do
-          expect { subject.validate }.to raise_approval("validations/#{fixture}")
+          expect { validator.validate }.to raise_approval("validations/#{fixture}")
         end
       end
     end

--- a/spec/bashly/library_source_config_spec.rb
+++ b/spec/bashly/library_source_config_spec.rb
@@ -1,0 +1,26 @@
+describe LibrarySourceConfig do
+  fixtures = Dir['spec/fixtures/libraries_errors/*.yml']
+  subject { described_class.new path }
+
+  let(:path) { 'spec/fixtures/libraries/libraries.yml' }
+
+  describe '#validated_data' do
+    it 'returns the data after validating it' do
+      expect(subject).to receive(:validate)
+      expect(subject.validated_data).to eq subject.data
+    end
+  end
+
+  describe '#validate' do
+    fixtures.each do |path|
+      fixture_name = File.basename path, '.yml'
+      config = described_class.new path
+
+      context "with #{fixture_name}.yml" do
+        it 'raises an error' do
+          expect { config.validate }.to raise_approval("libraries_validation/#{fixture_name}")
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/libraries_validation/files_array.yml
+++ b/spec/fixtures/libraries_validation/files_array.yml
@@ -1,0 +1,4 @@
+# error: files must be an array
+database:
+  help: Help text
+  files: one_file.txt

--- a/spec/fixtures/libraries_validation/files_source.yml
+++ b/spec/fixtures/libraries_validation/files_source.yml
@@ -1,0 +1,6 @@
+# error: files must have a source
+database:
+  help: Help text
+  files:
+    - target: some_target
+

--- a/spec/fixtures/libraries_validation/files_target.yml
+++ b/spec/fixtures/libraries_validation/files_target.yml
@@ -1,0 +1,6 @@
+# error: files must have a target
+database:
+  help: Help text
+  files:
+    - source: some_source
+

--- a/spec/fixtures/libraries_validation/handler_string.yml
+++ b/spec/fixtures/libraries_validation/handler_string.yml
@@ -1,0 +1,7 @@
+# error: handler must be a string (optional)
+database:
+  help: Help text
+  handler: 1
+  files:
+    - source: "database/database.sh"
+      target: "%{user_lib_dir}/database.%{user_ext}"

--- a/spec/fixtures/libraries_validation/help_string.yml
+++ b/spec/fixtures/libraries_validation/help_string.yml
@@ -1,0 +1,6 @@
+# error: help must be a string
+database:
+  help: 1
+  files:
+    - source: "database/database.sh"
+      target: "%{user_lib_dir}/database.%{user_ext}"

--- a/spec/fixtures/libraries_validation/message_string.yml
+++ b/spec/fixtures/libraries_validation/message_string.yml
@@ -1,0 +1,7 @@
+# error: post_install_message must be a string (optional)
+database:
+  help: Help text
+  post_install_message: 1
+  files:
+    - source: "database/database.sh"
+      target: "%{user_lib_dir}/database.%{user_ext}"

--- a/spec/fixtures/libraries_validation/root_hash.yml
+++ b/spec/fixtures/libraries_validation/root_hash.yml
@@ -1,0 +1,6 @@
+# error: must be a hash
+- database:
+    help: Add database utilities
+    files:
+      - source: "database/database.sh"
+        target: "%{user_lib_dir}/database.%{user_ext}"

--- a/spec/fixtures/libraries_validation/usage_string.yml
+++ b/spec/fixtures/libraries_validation/usage_string.yml
@@ -1,0 +1,7 @@
+# error: usage must be a string (optional)
+database:
+  help: Help text
+  usage: 1
+  files:
+    - source: "database/database.sh"
+      target: "%{user_lib_dir}/database.%{user_ext}"


### PR DESCRIPTION
Instead of loading the `libraries.yml` straight with the YAML library, this PR adds a `LibrarySourceConfig` model that loads and validates the input data using `ValidationHelpers` (similarly to the primary `ConfigValidator`).

cc #439