### PR TITLE
Fix shfmt excess newlines violation when using `--env production`

### DIFF
--- a/lib/bashly/libraries/config/config.sh
+++ b/lib/bashly/libraries/config/config.sh
@@ -8,7 +8,6 @@
 ## - Use any of the following functions to access and manipulate the values.
 ## - INI sections are optional (i.e., sectionless key=value pairs are allowed).
 ##
-
 ## Show all the key=value pairs from your config file
 config_show() {
   config_load

--- a/lib/bashly/libraries/ini/ini.sh
+++ b/lib/bashly/libraries/ini/ini.sh
@@ -25,7 +25,6 @@
 ##   unset ini[section1.key1]
 ##   ini_save path/to/config.ini
 ##
-
 ## Load an INI file and populate the associative array `ini`.
 ini_load() {
   declare -gA ini


### PR DESCRIPTION
cc #443