### PR TITLE
Fix some incompatibilities with strict mode

### DIFF
--- a/examples/config/src/lib/config.sh
+++ b/examples/config/src/lib/config.sh
@@ -8,7 +8,6 @@
 ## - Use any of the following functions to access and manipulate the values.
 ## - INI sections are optional (i.e., sectionless key=value pairs are allowed).
 ##
-
 ## Show all the key=value pairs from your config file
 config_show() {
   config_load
@@ -28,8 +27,8 @@ config_show() {
 ##   theme="$(config_get interface.theme)"
 ##
 config_get() {
-  local key="$1"
-  local default_value="$2"
+  local key="${1-}"
+  local default_value="${2-}"
 
   config_load
   echo "${ini["$key"]:-$default_value}"
@@ -40,7 +39,7 @@ config_get() {
 ##   config_set cloud.provider aws
 ##
 config_set() {
-  local key="$1"
+  local key="${1-}"
   shift
   local value="$*"
 
@@ -54,7 +53,7 @@ config_set() {
 ##   config_del login.email
 ##
 config_del() {
-  local key="$1"
+  local key="${1-}"
 
   config_load
   unset "ini[$key]"
@@ -93,7 +92,7 @@ config_reload() {
 ## Load an INI file (unless loaded) and populate the associative array
 ## NOTE: Normally there is no need to call this function, it is called as needed
 config_load() {
-  [[ "$config_loaded" == "true" ]] && return
+  [[ "${config_loaded-}" == "true" ]] && return
 
   declare -g CONFIG_FILE=${CONFIG_FILE:=config.ini}
   declare -g config_loaded=true

--- a/examples/config/src/lib/ini.sh
+++ b/examples/config/src/lib/ini.sh
@@ -25,7 +25,6 @@
 ##   unset ini[section1.key1]
 ##   ini_save path/to/config.ini
 ##
-
 ## Load an INI file and populate the associative array `ini`.
 ini_load() {
   declare -gA ini

--- a/examples/help-command/src/help_command.sh
+++ b/examples/help-command/src/help_command.sh
@@ -10,7 +10,7 @@
 ##       - name: command
 ##         help: Help subject
 ##
-command="${args[command]}"
+command="${args[command]:-}"
 long_usage=yes
 
 if [[ -z "$command" ]]; then

--- a/examples/ini/src/get_command.sh
+++ b/examples/ini/src/get_command.sh
@@ -1,8 +1,8 @@
 # Using the standard library (lib/ini.sh) to show a value from the config
 ini_load config.ini
 
-key="${args[key]}"
-value=${ini[$key]}
+key="${args[key]:-}"
+value=${ini[$key]:-}
 
 if [[ "$value" ]]; then
   echo "$key = $value"

--- a/examples/ini/src/lib/ini.sh
+++ b/examples/ini/src/lib/ini.sh
@@ -25,7 +25,6 @@
 ##   unset ini[section1.key1]
 ##   ini_save path/to/config.ini
 ##
-
 ## Load an INI file and populate the associative array `ini`.
 ini_load() {
   declare -gA ini

--- a/examples/render-mandoc/docs/download.1
+++ b/examples/render-mandoc/docs/download.1
@@ -14,7 +14,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "download" "1" "October 2023" "Version 0.1.0" "Sample application"
+.TH "download" "1" "November 2023" "Version 0.1.0" "Sample application"
 .hy
 .SH NAME
 .PP

--- a/examples/render-mandoc/docs/download.md
+++ b/examples/render-mandoc/docs/download.md
@@ -1,6 +1,6 @@
 % download(1) Version 0.1.0 | Sample application
 % Lana Lang
-% October 2023
+% November 2023
 
 NAME
 ==================================================

--- a/lib/bashly/libraries/config/config.sh
+++ b/lib/bashly/libraries/config/config.sh
@@ -27,8 +27,8 @@ config_show() {
 ##   theme="$(config_get interface.theme)"
 ##
 config_get() {
-  local key="$1"
-  local default_value="$2"
+  local key="${1-}"
+  local default_value="${2-}"
 
   config_load
   echo "${ini["$key"]:-$default_value}"
@@ -39,7 +39,7 @@ config_get() {
 ##   config_set cloud.provider aws
 ##
 config_set() {
-  local key="$1"
+  local key="${1-}"
   shift
   local value="$*"
 
@@ -53,7 +53,7 @@ config_set() {
 ##   config_del login.email
 ##
 config_del() {
-  local key="$1"
+  local key="${1-}"
 
   config_load
   unset "ini[$key]"
@@ -92,7 +92,7 @@ config_reload() {
 ## Load an INI file (unless loaded) and populate the associative array
 ## NOTE: Normally there is no need to call this function, it is called as needed
 config_load() {
-  [[ "$config_loaded" == "true" ]] && return
+  [[ "${config_loaded-}" == "true" ]] && return
 
   declare -g CONFIG_FILE=${CONFIG_FILE:=config.ini}
   declare -g config_loaded=true

--- a/lib/bashly/libraries/help/help_command.sh
+++ b/lib/bashly/libraries/help/help_command.sh
@@ -10,7 +10,7 @@
 ##       - name: command
 ##         help: Help subject
 ##
-command="${args[command]}"
+command="${args[command]:-}"
 long_usage=yes
 
 if [[ -z "$command" ]]; then

--- a/lib/bashly/views/command/whitelist_filter.gtx
+++ b/lib/bashly/views/command/whitelist_filter.gtx
@@ -12,7 +12,7 @@ if whitelisted_args.any? or whitelisted_flags.any?
       > done
 
     else
-      > if [[ -n ${args['{{ arg.name }}']} ]] && [[ ! ${args['{{ arg.name }}']} =~ ^({{ arg.allowed.join '|' }})$ ]]; then
+      > if [[ -n ${args['{{ arg.name }}']:-} ]] && [[ ! ${args['{{ arg.name }}']:-} =~ ^({{ arg.allowed.join '|' }})$ ]]; then
       >   printf "%s\n" "{{ strings[:disallowed_argument] % { name: arg.name, allowed: arg.allowed.join(', ') } }}" >&2
       >   exit 1
       > fi
@@ -31,7 +31,7 @@ if whitelisted_args.any? or whitelisted_flags.any?
       > done
     
     else
-      > if [[ ${args['{{ flag.name }}']} ]] && [[ ! ${args['{{ flag.name }}']} =~ ^({{ flag.allowed.join '|' }})$ ]]; then
+      > if [[ ${args['{{ flag.name }}']:-} ]] && [[ ! ${args['{{ flag.name }}']:-} =~ ^({{ flag.allowed.join '|' }})$ ]]; then
       >   printf "%s\n" "{{ strings[:disallowed_flag] % { name: flag.name, allowed: flag.allowed.join(', ') } }}" >&2
       >   exit 1
       > fi

--- a/spec/approvals/examples/render-mandoc
+++ b/spec/approvals/examples/render-mandoc
@@ -44,4 +44,4 @@ ISSUE TRACKER
 AUTHORS
        Lana Lang.
 
-Version 0.1.0                    October 2023                      download(1)
+Version 0.1.0                    November 2023                     download(1)

--- a/spec/approvals/libraries/render/mandoc/render-1-download.1
+++ b/spec/approvals/libraries/render/mandoc/render-1-download.1
@@ -29,4 +29,4 @@ EXAMPLES
               download example.com ./output -f
 
 
-Version 0.1.0                    MONTH YEAR                      download(1)
+Version 0.1.0                    MONTH YEAR ... APPNAME

--- a/spec/bashly/integration/examples_spec.rb
+++ b/spec/bashly/integration/examples_spec.rb
@@ -7,6 +7,10 @@
 # EXAMPLE=yaml bundle exec run spec examples
 
 describe 'generated bash scripts' do
+  # Make sure all examples are generated with strict mode
+  before { ENV['BASHLY_STRICT'] = 'yes' }
+  after { ENV['BASHLY_STRICT'] = nil }
+
   # Test public examples from the examples folder...
   examples = Dir['examples/*'].select { |f| File.directory? f }
 

--- a/spec/bashly/libraries/render_mandoc_spec.rb
+++ b/spec/bashly/libraries/render_mandoc_spec.rb
@@ -31,7 +31,7 @@ describe 'libraries/render/mandoc' do
         expect(`man "#{target}/download.1" | col -bx`)
           .to match_approval('libraries/render/mandoc/render-1-download.1')
           .diff(leeway)
-          .except(/\w{3,9} 202\d/, 'MONTH YEAR')
+          .except(/\w{3,9} 202\d.*/, 'MONTH YEAR ... APPNAME')
       end
     end
 
@@ -41,7 +41,7 @@ describe 'libraries/render/mandoc' do
       it 'saves a markdown and man files for each command' do
         expect { subject.instance_eval render_script }
           .to output_approval('libraries/render/mandoc/render-2')
-          .except(/\w{3,9} 202\d/, 'MONTH YEAR')
+          .except(/\w{3,9} 202\d.*/, 'MONTH YEAR ... APPNAME')
 
         expect(File.read "#{target}/cli-download.md")
           .to match_approval('libraries/render/mandoc/render-2-download.md')

--- a/spec/fixtures/workspaces/environment-variables-initialize/src/initialize.sh
+++ b/spec/fixtures/workspaces/environment-variables-initialize/src/initialize.sh
@@ -1,10 +1,10 @@
-if [[ -n "$API_KEY" ]]; then
+if [[ -n "${API_KEY-}" ]]; then
   echo "PASS: API_KEY=$API_KEY"
 else
   echo "FAIL: API_KEY is empty"
 fi
 
-if [[ -z "$NESTED_VAR" ]]; then
+if [[ -z "${NESTED_VAR-}" ]]; then
   echo "PASS: NESTED_VAR is empty"
 else
   echo "FAIL: NESTED_VAR=$NESTED_VAR"


### PR DESCRIPTION
As reported in #445 - it appears that some rendering views are incompatible with `set -u` strict mode, and cause an `unbound variable` in the rendered script. This PR fixes it and improves tests to cover this use case.

Notable changes:

1. Some views and libraries were changed to avoid `unbound variable` by changing `$arg['something']` to `${arg['something']:-}` (or a similar syntax as appropriate).
2. The examples spec was changed to enable strict mode before running to ensure all examples are generated in strict mode and pass tests.



