### PR TITLE
Disallow multiple repeatable args, and a repeatable arg that is not the last one

### DIFF
--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -212,7 +212,8 @@ module Bashly
         assert repeatable_args < 2, "#{key}.args cannot have more than one repeatable args"
 
         if repeatable_args == 1
-          assert value['args'].last['repeatable'], "#{key}.args cannot contain a repeatable arg unless it is the last one"
+          assert value['args'].last['repeatable'],
+            "#{key}.args cannot contain a repeatable arg unless it is the last one"
         end
       end
 

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -207,6 +207,15 @@ module Bashly
         refute repeatable_arg, "#{key}.catch_all makes no sense with repeatable arg (#{repeatable_arg})"
       end
 
+      if value['args']
+        repeatable_args = value['args'].count { |a| a['repeatable'] }
+        assert repeatable_args < 2, "#{key}.args cannot have more than one repeatable args"
+
+        if repeatable_args == 1
+          assert value['args'].last['repeatable'], "#{key}.args cannot contain a repeatable arg unless it is the last one"
+        end
+      end
+
       if value['expose']
         assert value['commands'], "#{key}.expose makes no sense without nub`commands`"
       end

--- a/spec/approvals/validations/arg_repeatable_more_than_one
+++ b/spec/approvals/validations/arg_repeatable_more_than_one
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.args cannot have more than one repeatable args>

--- a/spec/approvals/validations/arg_repeatable_not_last
+++ b/spec/approvals/validations/arg_repeatable_not_last
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.args cannot contain a repeatable arg unless it is the last one>

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -19,6 +19,29 @@
       - name: ok
       - help: there is no name
 
+:arg_repeatable_more_than_one:
+  name: invalid
+  help: can only have one repeatable arg
+  args:
+  - name: source
+    required: true
+    repeatable: true
+    help: URL to download from
+  - name: target
+    repeatable: true
+    help: Target filename
+
+:arg_repeatable_not_last:
+  name: invalid
+  help: can the last arg can be repeatable
+  args:
+  - name: source
+    required: true
+    repeatable: true
+    help: URL to download from
+  - name: target
+    help: Target filename
+
 :command_catch_all_type:
   name: invalid
   help: catch_all must be boolean, string, or hash


### PR DESCRIPTION
Having multiple repeatable args, or a repeatable arg that is not the last one makes no sense (and creates an invalid bash script).

This PR adds a validation for these two cases.