### PR TITLE
Allow `flag.default` and `arg.default` to be an array if `repeatable` is true

### DIFF
--- a/examples/repeatable-arg/README.md
+++ b/examples/repeatable-arg/README.md
@@ -26,16 +26,21 @@ version: 0.1.0
 args:
 - name: file
   help: One or more files to process
-  required: true
 
   # Setting repeatable to true means that the user can provide multiple arguments
   # for it.
   # The argument will be received as a quoted and space-delimited string which
-  # needs to be converted to an array with `eval "data=(${args[file]})"`
+  # needs to be converted to an array with `eval "data=(${args[file]})"`.
   repeatable: true
 
-  # Setting unique to true will ignore non-unique repeating values
+  # Setting unique to true will ignore non-unique repeating values.
   unique: true
+
+  # Setting default value(s) for a repeatable argument should be done in an
+  # array form.
+  default:
+  - file1
+  - file2
 
 examples:
 - upcase README.md LICENSE
@@ -47,7 +52,7 @@ examples:
 ````bash
 # Convert the space delimited string to an array
 files=''
-eval "files=(${args[file]})"
+eval "files=(${args[file]:-})"
 
 echo
 echo "files:"
@@ -72,7 +77,7 @@ inspect_args
 upcase - Sample application to demonstrate the use of repeatable arguments
 
 Usage:
-  upcase FILE...
+  upcase [FILE...]
   upcase --help | -h
   upcase --version | -v
 
@@ -86,11 +91,30 @@ Options:
 Arguments:
   FILE...
     One or more files to process
+    Default: file1, file2
 
 Examples:
   upcase README.md LICENSE
   upcase *.md
 
+
+
+````
+
+### `$ ./upcase`
+
+````shell
+
+files:
+  path: file1:
+  content: content of file1
+  upcase: CONTENT OF FILE1
+  path: file2:
+  content: content of file2
+  upcase: CONTENT OF FILE2
+
+args:
+- ${args[file]} = file1 file2
 
 
 ````

--- a/examples/repeatable-arg/README.md
+++ b/examples/repeatable-arg/README.md
@@ -36,8 +36,8 @@ args:
   # Setting unique to true will ignore non-unique repeating values.
   unique: true
 
-  # Setting default value(s) for a repeatable argument should be done in an
-  # array form.
+  # Setting default value(s) for a repeatable argument may be done in an array
+  # form (or a string form if it is a single default value only).
   default:
   - file1
   - file2

--- a/examples/repeatable-arg/src/bashly.yml
+++ b/examples/repeatable-arg/src/bashly.yml
@@ -15,8 +15,8 @@ args:
   # Setting unique to true will ignore non-unique repeating values.
   unique: true
 
-  # Setting default value(s) for a repeatable argument should be done in an
-  # array form.
+  # Setting default value(s) for a repeatable argument may be done in an array
+  # form (or a string form if it is a single default value only).
   default:
   - file1
   - file2

--- a/examples/repeatable-arg/src/bashly.yml
+++ b/examples/repeatable-arg/src/bashly.yml
@@ -5,16 +5,21 @@ version: 0.1.0
 args:
 - name: file
   help: One or more files to process
-  required: true
 
   # Setting repeatable to true means that the user can provide multiple arguments
   # for it.
   # The argument will be received as a quoted and space-delimited string which
-  # needs to be converted to an array with `eval "data=(${args[file]})"`
+  # needs to be converted to an array with `eval "data=(${args[file]})"`.
   repeatable: true
 
-  # Setting unique to true will ignore non-unique repeating values
+  # Setting unique to true will ignore non-unique repeating values.
   unique: true
+
+  # Setting default value(s) for a repeatable argument should be done in an
+  # array form.
+  default:
+  - file1
+  - file2
 
 examples:
 - upcase README.md LICENSE

--- a/examples/repeatable-arg/src/root_command.sh
+++ b/examples/repeatable-arg/src/root_command.sh
@@ -1,6 +1,6 @@
 # Convert the space delimited string to an array
 files=''
-eval "files=(${args[file]})"
+eval "files=(${args[file]:-})"
 
 echo
 echo "files:"

--- a/examples/repeatable-arg/test.sh
+++ b/examples/repeatable-arg/test.sh
@@ -7,6 +7,7 @@ bashly generate
 ### Try Me ###
 
 ./upcase -h
+./upcase
 ./upcase file1
 ./upcase file*
 ./upcase file1 file2 file1

--- a/examples/repeatable-flag/README.md
+++ b/examples/repeatable-flag/README.md
@@ -44,8 +44,8 @@ flags:
   # Setting this to true will ignore repeating arguments that are not unique.
   unique: true
 
-  # Setting default value(s) for a repeatable flag argument should be done in
-  # an array form.
+  # Setting default value(s) for a repeatable flag argument may be done in an
+  # array form (or a string form if it is a single default value only).
   default:
   - file one
   - file-two

--- a/examples/repeatable-flag/README.md
+++ b/examples/repeatable-flag/README.md
@@ -28,12 +28,11 @@ flags:
   short: -d
   arg: data
   help: Provide data values
-  required: true
 
   # Setting this to true on a flag with an argument means the user can type it
   # multiple times, like --data a --data b.
   # The argument will be received as a quoted and space-delimited string which
-  # needs to be converted to an array with `eval "data=(${args[--data]})"`
+  # needs to be converted to an array with `eval "data=(${args[--data]})"`.
   repeatable: true
 
 - long: --path
@@ -42,8 +41,14 @@ flags:
   help: Specify one or more paths
   repeatable: true
 
-  # Setting this to true will ignore repeating arguments that are not unique
+  # Setting this to true will ignore repeating arguments that are not unique.
   unique: true
+
+  # Setting default value(s) for a repeatable flag argument should be done in
+  # an array form.
+  default:
+  - file one
+  - file-two
 
 - long: --verbose
   short: -v
@@ -63,7 +68,7 @@ examples:
 
 ````bash
 # Convert the space delimited string to an array
-eval "data=(${args[--data]})"
+eval "data=(${args[--data]:-})"
 
 echo "Data elements:"
 for i in "${data[@]}"; do
@@ -94,11 +99,12 @@ Usage:
   download --version
 
 Options:
-  --data, -d DATA (required) (repeatable)
+  --data, -d DATA (repeatable)
     Provide data values
 
   --path, -p LOCATION (repeatable)
     Specify one or more paths
+    Default: file one, file-two
 
   --verbose, -v (repeatable)
     Set verbosity level
@@ -117,6 +123,19 @@ Examples:
 
 ````
 
+### `$ ./download`
+
+````shell
+Data elements:
+
+Verbosity level: 1
+
+args:
+- ${args[--path]} = file\ one file-two
+
+
+````
+
 ### `$ ./download -d one -d "two three" -vvv`
 
 ````shell
@@ -128,6 +147,7 @@ Verbosity level: 3
 
 args:
 - ${args[--data]} = "one" "two three"
+- ${args[--path]} = file\ one file-two
 - ${args[--verbose]} = 3
 
 

--- a/examples/repeatable-flag/src/bashly.yml
+++ b/examples/repeatable-flag/src/bashly.yml
@@ -23,8 +23,8 @@ flags:
   # Setting this to true will ignore repeating arguments that are not unique.
   unique: true
 
-  # Setting default value(s) for a repeatable flag argument should be done in
-  # an array form.
+  # Setting default value(s) for a repeatable flag argument may be done in an
+  # array form (or a string form if it is a single default value only).
   default:
   - file one
   - file-two

--- a/examples/repeatable-flag/src/bashly.yml
+++ b/examples/repeatable-flag/src/bashly.yml
@@ -7,12 +7,11 @@ flags:
   short: -d
   arg: data
   help: Provide data values
-  required: true
 
   # Setting this to true on a flag with an argument means the user can type it
   # multiple times, like --data a --data b.
   # The argument will be received as a quoted and space-delimited string which
-  # needs to be converted to an array with `eval "data=(${args[--data]})"`
+  # needs to be converted to an array with `eval "data=(${args[--data]})"`.
   repeatable: true
 
 - long: --path
@@ -21,8 +20,14 @@ flags:
   help: Specify one or more paths
   repeatable: true
 
-  # Setting this to true will ignore repeating arguments that are not unique
+  # Setting this to true will ignore repeating arguments that are not unique.
   unique: true
+
+  # Setting default value(s) for a repeatable flag argument should be done in
+  # an array form.
+  default:
+  - file one
+  - file-two
 
 - long: --verbose
   short: -v

--- a/examples/repeatable-flag/src/root_command.sh
+++ b/examples/repeatable-flag/src/root_command.sh
@@ -1,5 +1,5 @@
 # Convert the space delimited string to an array
-eval "data=(${args[--data]})"
+eval "data=(${args[--data]:-})"
 
 echo "Data elements:"
 for i in "${data[@]}"; do

--- a/examples/repeatable-flag/test.sh
+++ b/examples/repeatable-flag/test.sh
@@ -7,5 +7,6 @@ bashly generate
 ### Try Me ###
 
 ./download -h
+./download
 ./download -d one -d "two three" -vvv
 ./download -d one --path /bin --path /usr/lib --path /bin

--- a/lib/bashly/concerns/validation_helpers.rb
+++ b/lib/bashly/concerns/validation_helpers.rb
@@ -61,7 +61,7 @@ module Bashly
       return unless value
 
       assert [Array, String].include?(value.class),
-        "#{key} must be a string or an array of strings"
+        "#{key} must be a string or an array"
 
       assert_array key, value, of: :string if value.is_a? Array
     end

--- a/lib/bashly/concerns/validation_helpers.rb
+++ b/lib/bashly/concerns/validation_helpers.rb
@@ -61,7 +61,7 @@ module Bashly
       return unless value
 
       assert [Array, String].include?(value.class),
-        "#{key} must be a string or an array"
+        "#{key} must be a string or an array of strings"
 
       assert_array key, value, of: :string if value.is_a? Array
     end

--- a/lib/bashly/concerns/validation_helpers.rb
+++ b/lib/bashly/concerns/validation_helpers.rb
@@ -31,7 +31,7 @@ module Bashly
       return unless of
 
       value.each_with_index do |val, i|
-        send "assert_#{of}".to_sym, "#{key}[#{i}]", val
+        send :"assert_#{of}", "#{key}[#{i}]", val
       end
     end
 

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -152,7 +152,8 @@ module Bashly
       end
 
       if value['unique']
-        assert value['arg'] && value['repeatable'], "#{key}.unique does not make sense without nub`arg` and nub`repeatable`"
+        assert value['arg'] && value['repeatable'],
+          "#{key}.unique does not make sense without nub`arg` and nub`repeatable`"
       end
 
       if value['default'].is_a? Array

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -91,7 +91,7 @@ module Bashly
       assert_hash key, value, keys: Script::Argument.option_keys
       assert_string "#{key}.name", value['name']
       assert_optional_string "#{key}.help", value['help']
-      assert_optional_string "#{key}.default", value['default']
+      assert_string_or_array "#{key}.default", value['default']
       assert_optional_string "#{key}.validate", value['validate']
       assert_boolean "#{key}.required", value['required']
       assert_boolean "#{key}.repeatable", value['repeatable']
@@ -106,6 +106,10 @@ module Bashly
       if value['unique']
         assert value['repeatable'], "#{key}.unique does not make sense without nub`repeatable`"
       end
+
+      if value['default'].is_a? Array
+        assert value['repeatable'], "#{key}.default array does not make sense without nub`repeatable`"
+      end
     end
 
     def assert_flag(key, value)
@@ -118,7 +122,7 @@ module Bashly
       assert_optional_string "#{key}.short", value['short']
       assert_optional_string "#{key}.help", value['help']
       assert_optional_string "#{key}.arg", value['arg']
-      assert_optional_string "#{key}.default", value['default']
+      assert_string_or_array "#{key}.default", value['default']
       assert_optional_string "#{key}.validate", value['validate']
 
       assert_boolean "#{key}.private", value['private']
@@ -149,6 +153,10 @@ module Bashly
 
       if value['unique']
         assert value['arg'] && value['repeatable'], "#{key}.unique does not make sense without nub`arg` and nub`repeatable`"
+      end
+
+      if value['default'].is_a? Array
+        assert value['repeatable'], "#{key}.default array does not make sense without nub`repeatable`"
       end
     end
 

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -110,10 +110,6 @@ module Bashly
       if value['default'].is_a? Array
         assert value['repeatable'], "#{key}.default array does not make sense without nub`repeatable`"
       end
-
-      if value['repeatable'] && value['default']
-        assert value['default'].is_a?(Array), "#{key}.default must be an array when using nub`repeatable`"
-      end
     end
 
     def assert_flag(key, value)
@@ -162,10 +158,6 @@ module Bashly
 
       if value['default'].is_a? Array
         assert value['repeatable'], "#{key}.default array does not make sense without nub`repeatable`"
-      end
-
-      if value['repeatable'] && value['default']
-        assert value['default'].is_a?(Array), "#{key}.default must be an array when using nub`repeatable`"
       end
     end
 

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -110,6 +110,10 @@ module Bashly
       if value['default'].is_a? Array
         assert value['repeatable'], "#{key}.default array does not make sense without nub`repeatable`"
       end
+
+      if value['repeatable'] && value['default']
+        assert value['default'].is_a?(Array), "#{key}.default must be an array when using nub`repeatable`"
+      end
     end
 
     def assert_flag(key, value)
@@ -158,6 +162,10 @@ module Bashly
 
       if value['default'].is_a? Array
         assert value['repeatable'], "#{key}.default array does not make sense without nub`repeatable`"
+      end
+
+      if value['repeatable'] && value['default']
+        assert value['default'].is_a?(Array), "#{key}.default must be an array when using nub`repeatable`"
       end
     end
 

--- a/lib/bashly/render_context.rb
+++ b/lib/bashly/render_context.rb
@@ -1,4 +1,4 @@
-require 'date'    # for use by template render scripts
+require 'date' # for use by template render scripts
 require 'colsole'
 
 module Bashly

--- a/lib/bashly/script/argument.rb
+++ b/lib/bashly/script/argument.rb
@@ -12,7 +12,13 @@ module Bashly
       end
 
       def default_string
-        default.is_a?(Array) ? Shellwords.shelljoin(default) : default
+        if default.is_a?(Array)
+          Shellwords.shelljoin default
+        elsif default.is_a?(String) && repeatable
+          Shellwords.shellescape default
+        else
+          default
+        end
       end
 
       def usage_string

--- a/lib/bashly/script/argument.rb
+++ b/lib/bashly/script/argument.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module Bashly
   module Script
     class Argument < Base
@@ -7,6 +9,10 @@ module Bashly
             allowed default help name repeatable required unique validate
           ]
         end
+      end
+
+      def default_string
+        default.is_a?(Array) ? Shellwords.shelljoin(default) : default
       end
 
       def usage_string

--- a/lib/bashly/script/flag.rb
+++ b/lib/bashly/script/flag.rb
@@ -22,6 +22,10 @@ module Bashly
         end
       end
 
+      def default_string
+        default.is_a?(Array) ? Shellwords.shelljoin(default) : default
+      end
+
       def name
         long || short
       end

--- a/lib/bashly/script/flag.rb
+++ b/lib/bashly/script/flag.rb
@@ -23,7 +23,13 @@ module Bashly
       end
 
       def default_string
-        default.is_a?(Array) ? Shellwords.shelljoin(default) : default
+        if default.is_a?(Array)
+          Shellwords.shelljoin default
+        elsif default.is_a?(String) && repeatable
+          Shellwords.shellescape default
+        else
+          default
+        end
       end
 
       def name

--- a/lib/bashly/views/argument/usage.gtx
+++ b/lib/bashly/views/argument/usage.gtx
@@ -8,7 +8,11 @@ if allowed
 end
 
 if default
-  > printf "    {{ strings[:default] % { value: default } }}\n"
+  if default.is_a? Array
+    > printf "    {{ strings[:default] % { value: default.join(', ') } }}\n"
+  else
+    > printf "    {{ strings[:default] % { value: default } }}\n"
+  end
 end
 
 > echo

--- a/lib/bashly/views/command/default_assignments.gtx
+++ b/lib/bashly/views/command/default_assignments.gtx
@@ -2,11 +2,11 @@ if default_args.any? or default_flags.any?
   = view_marker
 
   default_args.each do |arg|
-    > [[ -n ${args['{{ arg.name }}']:-} ]] || args['{{ arg.name }}']="{{ arg.default }}"
+    > [[ -n ${args['{{ arg.name }}']:-} ]] || args['{{ arg.name }}']="{{ arg.default_string }}"
   end
 
   default_flags.each do |flag|
-    > [[ -n ${args['{{ flag.name }}']:-} ]] || args['{{ flag.name }}']="{{ flag.default }}"
+    > [[ -n ${args['{{ flag.name }}']:-} ]] || args['{{ flag.name }}']="{{ flag.default_string }}"
   end
 
   >

--- a/lib/bashly/views/flag/usage.gtx
+++ b/lib/bashly/views/flag/usage.gtx
@@ -4,11 +4,15 @@
 > printf "{{ help.wrap(76).indent(4).sanitize_for_print }}\n"
 
 if allowed
-> printf "    {{ strings[:allowed] % { values: allowed.join(', ') } }}\n"
+  > printf "    {{ strings[:allowed] % { values: allowed.join(', ') } }}\n"
 end
 
 if default
-> printf "    {{ strings[:default] % { value: default } }}\n"
+  if default.is_a? Array
+    > printf "    {{ strings[:default] % { value: default.join(', ') } }}\n"
+  else
+    > printf "    {{ strings[:default] % { value: default } }}\n"
+  end
 end
 
 > echo

--- a/spec/approvals/examples/repeatable-arg
+++ b/spec/approvals/examples/repeatable-arg
@@ -7,7 +7,7 @@ run ./upcase --help to test your bash script
 upcase - Sample application to demonstrate the use of repeatable arguments
 
 Usage:
-  upcase FILE...
+  upcase [FILE...]
   upcase --help | -h
   upcase --version | -v
 
@@ -21,11 +21,24 @@ Options:
 Arguments:
   FILE...
     One or more files to process
+    Default: file1, file2
 
 Examples:
   upcase README.md LICENSE
   upcase *.md
 
++ ./upcase
+
+files:
+  path: file1:
+  content: content of file1
+  upcase: CONTENT OF FILE1
+  path: file2:
+  content: content of file2
+  upcase: CONTENT OF FILE2
+
+args:
+- ${args[file]} = file1 file2
 + ./upcase file1
 
 files:

--- a/spec/approvals/examples/repeatable-flag
+++ b/spec/approvals/examples/repeatable-flag
@@ -12,11 +12,12 @@ Usage:
   download --version
 
 Options:
-  --data, -d DATA (required) (repeatable)
+  --data, -d DATA (repeatable)
     Provide data values
 
   --path, -p LOCATION (repeatable)
     Specify one or more paths
+    Default: file one, file-two
 
   --verbose, -v (repeatable)
     Set verbosity level
@@ -31,6 +32,13 @@ Examples:
   download -d one -d "two three" -vvv
   download -d one -p /usr/bin -p /tmp
 
++ ./download
+Data elements:
+
+Verbosity level: 1
+
+args:
+- ${args[--path]} = file\ one file-two
 + ./download -d one -d 'two three' -vvv
 Data elements:
 one
@@ -40,6 +48,7 @@ Verbosity level: 3
 
 args:
 - ${args[--data]} = "one" "two three"
+- ${args[--path]} = file\ one file-two
 - ${args[--verbose]} = 3
 + ./download -d one --path /bin --path /usr/lib --path /bin
 Data elements:

--- a/spec/approvals/validations/arg_default_array_without_repeatable
+++ b/spec/approvals/validations/arg_default_array_without_repeatable
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.args[0].default array does not make sense without nub`repeatable`>

--- a/spec/approvals/validations/arg_default_string_with_repeatable
+++ b/spec/approvals/validations/arg_default_string_with_repeatable
@@ -1,1 +1,0 @@
-#<Bashly::ConfigurationError: root.args[0].default must be an array when using nub`repeatable`>

--- a/spec/approvals/validations/arg_default_string_with_repeatable
+++ b/spec/approvals/validations/arg_default_string_with_repeatable
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.args[0].default must be an array when using nub`repeatable`>

--- a/spec/approvals/validations/flag_default_array_without_repeatable
+++ b/spec/approvals/validations/flag_default_array_without_repeatable
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.flags[0].default array does not make sense without nub`repeatable`>

--- a/spec/approvals/validations/flag_default_string_with_repeatable
+++ b/spec/approvals/validations/flag_default_string_with_repeatable
@@ -1,1 +1,0 @@
-#<Bashly::ConfigurationError: root.flags[0].default must be an array when using nub`repeatable`>

--- a/spec/approvals/validations/flag_default_string_with_repeatable
+++ b/spec/approvals/validations/flag_default_string_with_repeatable
@@ -1,0 +1,1 @@
+#<Bashly::ConfigurationError: root.flags[0].default must be an array when using nub`repeatable`>

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -13,14 +13,6 @@
     - spaced file
     - other-file
 
-:arg_default_string_with_repeatable:
-  name: invalid
-  help: default cannot be a string with repeatable
-  args:
-  - name: path
-    repeatable: true
-    default: spaced file
-
 :arg_nested_name:
   name: invalid
   help: last nested arg does not have a name
@@ -283,15 +275,6 @@
     default:
     - spaced file
     - other-file
-
-:flag_default_string_with_repeatable:
-  name: invalid
-  help: default cannot be a string with repeatable
-  flags:
-  - long: --path
-    arg: location
-    repeatable: true
-    default: spaced file
 
 :flag_allowed_without_arg:
   name: invalid

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -59,22 +59,15 @@
     help: Target filename
     unique: true
 
-:command_catch_all_type:
+:catch_all_and_repeatable_arg:
   name: invalid
-  help: catch_all must be boolean, string, or hash
-  catch_all: [1,2]
-
-:command_catch_all_hash:
-  name: invalid
-  catch_all:
-    help: catch_all hash must have a label
-
-:command_catch_all_valid:
-  name: invalid
-  catch_all:
-    label: acceptable
-    help: catch_all.required should be boolean
-    required: 1
+  help: catch_all and repeatable arg make no sense together
+  catch_all: true
+  args:
+  - name: path
+    help: Path to one or more files
+    repeatable: true
+    required: true
 
 :command_catch_all_commands:
   name: invalid
@@ -83,6 +76,23 @@
     help: catch_all makes no sense with commands
   commands:
   - name: config
+
+:command_catch_all_hash:
+  name: invalid
+  catch_all:
+    help: catch_all hash must have a label
+
+:command_catch_all_type:
+  name: invalid
+  help: catch_all must be boolean, string, or hash
+  catch_all: [1,2]
+
+:command_catch_all_valid:
+  name: invalid
+  catch_all:
+    label: acceptable
+    help: catch_all.required should be boolean
+    required: 1
 
 :command_dependencies_invalid:
   name: invalid
@@ -117,22 +127,22 @@
     docker:
       invalid_key: goes here
 
-:command_expose_invalid_type:
-  name: invalid
-  help: expose should be boolean or 'always'
-  commands:
-  - name: config
-    expose: 1
-    commands:
-    - name: edit
-    - name: show
-
 :command_expose_invalid_string:
   name: invalid
   help: expose should be boolean or 'always'
   commands:
   - name: config
     expose: never
+    commands:
+    - name: edit
+    - name: show
+
+:command_expose_invalid_type:
+  name: invalid
+  help: expose should be boolean or 'always'
+  commands:
+  - name: config
+    expose: 1
     commands:
     - name: edit
     - name: show
@@ -172,13 +182,13 @@
   name: -invalid
   help: command.name must not start with a hyphen
 
+:command_name_missing:
+  help: there is no name
+
 :command_version:
   name: invalid
   help: version should be a string or a number
   version: [1, 0, 0]
-
-:command_name_missing:
-  help: there is no name
 
 :commands_and_args:
   name: invalid
@@ -210,18 +220,6 @@
     default: development
     private: 1
 
-:flag_long:
-  name: invalid
-  help: the long flag is not in the form of --force
-  flags:
-  - long: force
-
-:flag_short:
-  name: invalid
-  help: the short flag is not in the form of -f
-  flags:
-  - short: f
-
 :flag_arg:
   name: invalid
   help: the flag.arg should not start with --
@@ -229,52 +227,13 @@
   - long: --user
     arg: --name
 
-:flag_conflicts_type:
+:flag_allowed_and_completions:
   name: invalid
-  help: flag.conflicts should be an array
+  help: flag with both allowed and completions
   flags:
-  - long: --cache
-    conflicts: --no-cache
-
-:flag_conflicts_array:
-  name: invalid
-  help: flag.conflicts should be an array of strings
-  flags:
-  - long: --cache
-    conflicts: [1, 2]
-
-:flag_required_and_default:
-  name: invalid
-  help: flag cannot have both required and default
-  flags:
-  - long: --role
-    arg: name
-    required: true
-    default: admin
-
-:flag_default_without_arg:
-  name: invalid
-  help: flag must have an arg when using default
-  flags:
-  - long: --role
-    default: admin
-
-:flag_default_without_arg:
-  name: invalid
-  help: flag must have an arg when using default
-  flags:
-  - long: --role
-    default: admin
-
-:flag_default_array_without_repeatable:
-  name: invalid
-  help: default cannot be an array without repeatable
-  flags:
-  - long: --path
-    arg: location
-    default:
-    - spaced file
-    - other-file
+  - long: --file
+    allowed: [one, two]
+    completions: [<file>]
 
 :flag_allowed_without_arg:
   name: invalid
@@ -288,15 +247,66 @@
   help: flag must have an arg when using completions
   flags:
   - long: --target
-    completions: [<dir>]
+    completions: [<dir>]    
 
-:flag_allowed_and_completions:
+:flag_conflicts_array:
   name: invalid
-  help: flag with both allowed and completions
+  help: flag.conflicts should be an array of strings
   flags:
-  - long: --file
-    allowed: [one, two]
-    completions: [<file>]
+  - long: --cache
+    conflicts: [1, 2]
+
+:flag_conflicts_type:
+  name: invalid
+  help: flag.conflicts should be an array
+  flags:
+  - long: --cache
+    conflicts: --no-cache
+
+:flag_default_array_without_repeatable:
+  name: invalid
+  help: default cannot be an array without repeatable
+  flags:
+  - long: --path
+    arg: location
+    default:
+    - spaced file
+    - other-file
+
+:flag_default_without_arg:
+  name: invalid
+  help: flag must have an arg when using default
+  flags:
+  - long: --role
+    default: admin
+
+:flag_default_without_arg:
+  name: invalid
+  help: flag must have an arg when using default
+  flags:
+  - long: --role
+    default: admin
+
+:flag_long:
+  name: invalid
+  help: the long flag is not in the form of --force
+  flags:
+  - long: force
+
+:flag_required_and_default:
+  name: invalid
+  help: flag cannot have both required and default
+  flags:
+  - long: --role
+    arg: name
+    required: true
+    default: admin
+
+:flag_short:
+  name: invalid
+  help: the short flag is not in the form of -f
+  flags:
+  - short: f
 
 :flag_unique_without_repeatable_and_arg:
   name: invalid
@@ -305,35 +315,6 @@
   - long: --ssh
     repeatable: true
     unique: true
-
-:root_alias:
-  name: invalid
-  help: root cannot have alias
-  alias: i
-
-:root_group:
-  name: invalid
-  help: root cannot have group
-  group: My Commands
-
-:root_default:
-  name: invalid
-  help: root cannot have default
-  default: true
-  args:
-  - name: ok
-
-:root_expose:
-  name: invalid
-  help: root cannot have expose
-  expose: true
-  commands:
-  - name: config
-
-:root_private:
-  name: invalid
-  help: root cannot have private
-  private: true
 
 :invalid_arg_keys:
   name: invalid
@@ -368,16 +349,6 @@
   flags:
   - long: --user
     disallowed: true
-  
-:catch_all_and_repeatable_arg:
-  name: invalid
-  help: catch_all and repeatable arg make no sense together
-  catch_all: true
-  args:
-  - name: path
-    help: Path to one or more files
-    repeatable: true
-    required: true
 
 :non_uniq_command_names:
   name: invalid
@@ -425,4 +396,32 @@
   args:
   - name: file
   - name: file
-  
+
+:root_alias:
+  name: invalid
+  help: root cannot have alias
+  alias: i
+
+:root_group:
+  name: invalid
+  help: root cannot have group
+  group: My Commands
+
+:root_default:
+  name: invalid
+  help: root cannot have default
+  default: true
+  args:
+  - name: ok
+
+:root_expose:
+  name: invalid
+  help: root cannot have expose
+  expose: true
+  commands:
+  - name: config
+
+:root_private:
+  name: invalid
+  help: root cannot have private
+  private: true

--- a/spec/fixtures/script/validations.yml
+++ b/spec/fixtures/script/validations.yml
@@ -4,6 +4,23 @@
   args:
   - name: --user
 
+:arg_default_array_without_repeatable:
+  name: invalid
+  help: default cannot be an array without repeatable
+  args:
+  - name: path
+    default:
+    - spaced file
+    - other-file
+
+:arg_default_string_with_repeatable:
+  name: invalid
+  help: default cannot be a string with repeatable
+  args:
+  - name: path
+    repeatable: true
+    default: spaced file
+
 :arg_nested_name:
   name: invalid
   help: last nested arg does not have a name
@@ -256,6 +273,25 @@
   flags:
   - long: --role
     default: admin
+
+:flag_default_array_without_repeatable:
+  name: invalid
+  help: default cannot be an array without repeatable
+  flags:
+  - long: --path
+    arg: location
+    default:
+    - spaced file
+    - other-file
+
+:flag_default_string_with_repeatable:
+  name: invalid
+  help: default cannot be a string with repeatable
+  flags:
+  - long: --path
+    arg: location
+    repeatable: true
+    default: spaced file
 
 :flag_allowed_without_arg:
   name: invalid

--- a/support/runfile/examples.runfile
+++ b/support/runfile/examples.runfile
@@ -1,9 +1,15 @@
 summary 'Regenerate example scripts'
 
+env_var 'EXAMPLE', 'If set, work only on example that include this string.'
+
 action :regen do
   # Patch the PATH to allow the extensible example to run properly
   ENV['PATH']="#{Dir.pwd}/examples/extensible:#{ENV['PATH']}"
   Example.all.each do |example|
+    if ENV['EXAMPLE']
+      next unless example.dir.include? ENV['EXAMPLE']
+    end
+
     say example.dir
     Dir.chdir example.dir do
       system 'bash test.sh >/dev/null 2>&1'


### PR DESCRIPTION
As raised in #461.

This PR adds the ability to use an array for the `default` value, when using `repeatable` for both `arg` and `flag`:

```yaml
name: cli
help: Sample application
version: 0.1.0

args:
- name: file
  repeatable: true # must be true, otherwise default array is not allowed
  unique: true
  help: Specify file
  allowed:
  - spaced file
  - other-file
  default:  # <== NEW: allow using an array here
  - spaced file
  - other-file

flags:
- long: --path
  short: -p
  repeatable: true # must be true, otherwise default array is not allowed
  unique: true
  arg: location
  allowed:
  - spaced file
  - other-file
  default:  # <== NEW: allow using an array here
  - spaced file
  - other-file
```