### PR TITLE
Support array in default

### DIFF
--- a/examples/catch-all/src/bashly.yml
+++ b/examples/catch-all/src/bashly.yml
@@ -8,8 +8,7 @@ catch_all: true
 args:
 - name: message
   required: true
-  default: [""]
-  x_a: 
+  help: Message
 
 flags:
 - long: --debug

--- a/examples/catch-all/src/bashly.yml
+++ b/examples/catch-all/src/bashly.yml
@@ -8,7 +8,8 @@ catch_all: true
 args:
 - name: message
   required: true
-  help: Message
+  default: [""]
+  x_a: 
 
 flags:
 - long: --debug

--- a/schemas/bashly.json
+++ b/schemas/bashly.json
@@ -41,7 +41,18 @@
                 "default": {
                     "title": "default",
                     "description": "A default value of the current positional argument\nhttps://bashly.dannyb.co/configuration/argument/#default",
-                    "type": "string",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
                     "examples": [
                         "*.jpg"
                     ]
@@ -159,7 +170,18 @@
                 "default": {
                     "title": "default",
                     "description": "A default value of the current flag\nhttps://bashly.dannyb.co/configuration/flag/#default",
-                    "type": "string",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
                     "examples": [
                         "*.jpg"
                     ]

--- a/schemas/bashly.json
+++ b/schemas/bashly.json
@@ -41,18 +41,7 @@
                 "default": {
                     "title": "default",
                     "description": "A default value of the current positional argument\nhttps://bashly.dannyb.co/configuration/argument/#default",
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    ],
+                    "type": "string",
                     "examples": [
                         "*.jpg"
                     ]

--- a/schemas/bashly.json
+++ b/schemas/bashly.json
@@ -41,7 +41,18 @@
                 "default": {
                     "title": "default",
                     "description": "A default value of the current positional argument\nhttps://bashly.dannyb.co/configuration/argument/#default",
-                    "type": "string",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
                     "examples": [
                         "*.jpg"
                     ]


### PR DESCRIPTION
closes #463

The easiest way to add array support for `default`.

To implement dependency between `repeatable` and `default` properties here `if` is required, but it means that common properties to `then` and `else` branches should be declared inside `definitions`. Will u accept such change if I make it?