### PR TITLE
Refactor `inspect_args` handling of environment variables

### DIFF
--- a/examples/command-aliases/README.md
+++ b/examples/command-aliases/README.md
@@ -147,6 +147,9 @@ Examples:
 args:
 - ${args[source]} = somefile
 
+environment variables:
+- $API_KEY = 
+
 
 ````
 
@@ -214,6 +217,9 @@ Examples:
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
 - ${args[source]} = somefile
+
+environment variables:
+- $API_KEY = 
 
 
 ````

--- a/examples/commands/README.md
+++ b/examples/commands/README.md
@@ -185,6 +185,10 @@ args:
 - ${args[source]} = sourcefile
 - ${args[target]} = targetfile
 
+environment variables:
+- $API_KEY = 
+- $DEFAULT_TARGET_LOCATION = 
+
 
 ````
 
@@ -234,6 +238,9 @@ missing required flag: --user, -u USER
 args:
 - ${args[source]} = sourcefile
 - ${args[--user]} = username
+
+environment variables:
+- $API_KEY = 
 
 
 ````

--- a/examples/environment-variables/README.md
+++ b/examples/environment-variables/README.md
@@ -14,8 +14,6 @@ $ bashly generate
 $ bashly generate
 ```
 
-<!-- include: src/verify_command.sh -->
-
 -----
 
 ## `bashly.yml`
@@ -59,15 +57,6 @@ commands:
     default: development
 ````
 
-## `src/verify_command.sh`
-
-````bash
-echo "# this file is located in 'src/verify_command.sh'"
-echo "# code for 'cli verify' goes here"
-echo "# you can edit it freely and regenerate (it will not be overwritten)"
-inspect_args
-
-````
 
 
 ## Output

--- a/examples/environment-variables/README.md
+++ b/examples/environment-variables/README.md
@@ -46,8 +46,16 @@ commands:
   
   # Using the `default: value` option will cause the value to variable to be 
   # set if it is not provided by the user.
+  - name: region
+    help: Cloud region
+    default: us-east-2
+
+  # Using the `allowed: [value1, value2]` option will halt the script's
+  # execution with a friendly error message, unless the variable matches one
+  # of the defined values.
   - name: environment
     help: One of development, production or test
+    allowed: [development, production, testing]
     default: development
 ````
 
@@ -58,11 +66,6 @@ echo "# this file is located in 'src/verify_command.sh'"
 echo "# code for 'cli verify' goes here"
 echo "# you can edit it freely and regenerate (it will not be overwritten)"
 inspect_args
-
-echo "environment:"
-echo "- API_KEY=${API_KEY:-}"
-echo "- ENVIRONMENT=${ENVIRONMENT:-}"
-echo "- MY_SECRET=${MY_SECRET:-}"
 
 ````
 
@@ -133,8 +136,13 @@ Environment Variables:
   MY_SECRET (required)
     Your secret
 
+  REGION
+    Cloud region
+    Default: us-east-2
+
   ENVIRONMENT
     One of development, production or test
+    Allowed: development, production, testing
     Default: development
 
 
@@ -156,10 +164,12 @@ missing required environment variable: MY_SECRET
 # code for 'cli verify' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
 args: none
-environment:
-- API_KEY=
-- ENVIRONMENT=development
-- MY_SECRET=there is no spoon
+
+environment variables:
+- $API_KEY = 
+- $ENVIRONMENT = development
+- $MY_SECRET = there is no spoon
+- $REGION = us-east-2
 
 
 ````
@@ -171,10 +181,12 @@ environment:
 # code for 'cli verify' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
 args: none
-environment:
-- API_KEY=
-- ENVIRONMENT=production
-- MY_SECRET=safe-with-me
+
+environment variables:
+- $API_KEY = 
+- $ENVIRONMENT = production
+- $MY_SECRET = safe-with-me
+- $REGION = us-east-2
 
 
 ````

--- a/examples/environment-variables/src/bashly.yml
+++ b/examples/environment-variables/src/bashly.yml
@@ -23,6 +23,14 @@ commands:
   
   # Using the `default: value` option will cause the value to variable to be 
   # set if it is not provided by the user.
+  - name: region
+    help: Cloud region
+    default: us-east-2
+
+  # Using the `allowed: [value1, value2]` option will halt the script's
+  # execution with a friendly error message, unless the variable matches one
+  # of the defined values.
   - name: environment
     help: One of development, production or test
+    allowed: [development, production, testing]
     default: development

--- a/examples/environment-variables/src/verify_command.sh
+++ b/examples/environment-variables/src/verify_command.sh
@@ -2,8 +2,3 @@ echo "# this file is located in 'src/verify_command.sh'"
 echo "# code for 'cli verify' goes here"
 echo "# you can edit it freely and regenerate (it will not be overwritten)"
 inspect_args
-
-echo "environment:"
-echo "- API_KEY=${API_KEY:-}"
-echo "- ENVIRONMENT=${ENVIRONMENT:-}"
-echo "- MY_SECRET=${MY_SECRET:-}"

--- a/examples/multiline/README.md
+++ b/examples/multiline/README.md
@@ -142,6 +142,9 @@ Examples:
 # you can edit it freely and regenerate (it will not be overwritten)
 args: none
 
+environment variables:
+- $MULTI_VITAMIN = 
+
 
 ````
 

--- a/lib/bashly/views/command/environment_variables_filter.gtx
+++ b/lib/bashly/views/command/environment_variables_filter.gtx
@@ -1,24 +1,26 @@
-if default_environment_variables.any? || required_environment_variables.any? ||
-  whitelisted_environment_variables.any?
-
-  = view_marker 
+if environment_variables.any?
+  = view_marker
   = render(:environment_variables_default)
 
-  if required_environment_variables.any?
-    required_environment_variables.each do |env_var|
-      > if [[ -z "${<%= env_var.name.upcase %>:-}" ]]; then
-      >   printf "{{ strings[:missing_required_environment_variable] % { var: env_var.name.upcase } }}\n" >&2
-      >   exit 1
-      > fi
-    end
+  environment_variables.each do |env_var|
+    > env_var_names+=("{{ env_var.name.upcase }}")
   end
+end
 
-  if whitelisted_environment_variables.any?
-    whitelisted_environment_variables.each do |env_var|
-      > if [[ -n "${<%= env_var.name.upcase %>:-}" ]] && [[ ! ${<%= env_var.name.upcase %>:-} =~ ^({{ env_var.allowed.join '|' }})$ ]]; then
-      >   printf "%s\n" "{{ strings[:disallowed_environment_variable] % { name: env_var.name.upcase, allowed: env_var.allowed.join(', ') } }}" >&2
-      >   exit 1
-      > fi
-    end
+if required_environment_variables.any?
+  required_environment_variables.each do |env_var|
+    > if [[ -z "${<%= env_var.name.upcase %>:-}" ]]; then
+    >   printf "{{ strings[:missing_required_environment_variable] % { var: env_var.name.upcase } }}\n" >&2
+    >   exit 1
+    > fi
+  end
+end
+
+if whitelisted_environment_variables.any?
+  whitelisted_environment_variables.each do |env_var|
+    > if [[ -n "${<%= env_var.name.upcase %>:-}" ]] && [[ ! ${<%= env_var.name.upcase %>:-} =~ ^({{ env_var.allowed.join '|' }})$ ]]; then
+    >   printf "%s\n" "{{ strings[:disallowed_environment_variable] % { name: env_var.name.upcase, allowed: env_var.allowed.join(', ') } }}" >&2
+    >   exit 1
+    > fi
   end
 end

--- a/lib/bashly/views/command/inspect_args.gtx
+++ b/lib/bashly/views/command/inspect_args.gtx
@@ -4,7 +4,9 @@
 >   if ((${#args[@]})); then
 >     readarray -t sorted_keys < <(printf '%s\n' "${!args[@]}" | sort)
 >     echo args:
->     for k in "${sorted_keys[@]}"; do echo "- \${args[$k]} = ${args[$k]}"; done
+>     for k in "${sorted_keys[@]}"; do
+>       echo "- \${args[$k]} = ${args[$k]}"
+>     done
 >   else
 >     echo args: none
 >   fi
@@ -22,16 +24,18 @@
 >     readarray -t sorted_keys < <(printf '%s\n' "${!deps[@]}" | sort)
 >     echo
 >     echo deps:
->     for k in "${sorted_keys[@]}"; do echo "- \${deps[$k]} = ${deps[$k]}"; done
+>     for k in "${sorted_keys[@]}"; do
+>       echo "- \${deps[$k]} = ${deps[$k]}"
+>     done
 >   fi
 >
-if environment_variables.any?
-  >   echo
-  >   echo environment variables:
-  environment_variables.each do |env_var|
-    >   echo "- \${{ env_var.name.upcase }} = ${<%= env_var.name.upcase %>:-unset}"
-  end
-  >
-end
+>   if ((${#env_var_names[@]})); then
+>     readarray -t sorted_names < <(printf '%s\n' "${env_var_names[@]}" | sort)
+>     echo
+>     echo "environment variables:"
+>     for k in "${sorted_names[@]}"; do
+>       echo "- \$$k = ${!k:-}"
+>     done
+>   fi
 > }
 > 

--- a/lib/bashly/views/command/run.gtx
+++ b/lib/bashly/views/command/run.gtx
@@ -4,6 +4,7 @@
 >   declare -A args=()
 >   declare -A deps=()
 >   declare -a other_args=()
+>   declare -a env_var_names=()
 >   declare -a input=()
 >   normalize_input "$@"
 >   parse_requirements "${input[@]}"

--- a/schemas/bashly.json
+++ b/schemas/bashly.json
@@ -421,6 +421,21 @@
       "type": "boolean",
       "default": true
     },
+    "environment-variables-allowed-property": {
+      "title": "allowed",
+      "description": "Valid values of the current environment variable\nhttps://bashly.dannyb.co/configuration/environment-variable/#allowed",
+      "type": "array",
+      "minLength": 1,
+      "uniqueItems": true,
+      "items": {
+        "description": "A valid value of the current environment variable",
+        "type": "string",
+        "minLength": 1,
+        "examples": [
+          "production"
+        ]
+      }
+    },
     "environment-variables-property": {
       "title": "environment variables",
       "description": "Environment variables of the current application\nhttps://bashly.dannyb.co/configuration/environment-variable/#environment-variable",
@@ -448,6 +463,9 @@
           },
           "required": {
             "$ref": "#/definitions/environment-variables-required-property"
+          },
+          "allowed": {
+            "$ref": "#/definitions/environment-variables-allowed-property"
           }
         },
         "if": {
@@ -473,6 +491,9 @@
             },
             "required": {
               "$ref": "#/definitions/environment-variables-required-property"
+            },
+            "allowed": {
+              "$ref": "#/definitions/environment-variables-allowed-property"
             }
           },
           "patternProperties": {

--- a/spec/approvals/examples/command-aliases
+++ b/spec/approvals/examples/command-aliases
@@ -71,7 +71,7 @@ args:
 - ${args[source]} = somefile
 
 environment variables:
-- $API_KEY = unset
+- $API_KEY = 
 + ./cli upload --help
 cli upload - Upload a file
 
@@ -124,4 +124,4 @@ args:
 - ${args[source]} = somefile
 
 environment variables:
-- $API_KEY = unset
+- $API_KEY = 

--- a/spec/approvals/examples/commands
+++ b/spec/approvals/examples/commands
@@ -85,7 +85,8 @@ args:
 - ${args[target]} = targetfile
 
 environment variables:
-- $API_KEY = unset
+- $API_KEY = 
+- $DEFAULT_TARGET_LOCATION = 
 + ./cli upload --help
 cli upload - Upload a file
 
@@ -120,4 +121,4 @@ args:
 - ${args[--user]} = username
 
 environment variables:
-- $API_KEY = unset
+- $API_KEY = 

--- a/spec/approvals/examples/environment-variables
+++ b/spec/approvals/examples/environment-variables
@@ -53,8 +53,13 @@ Environment Variables:
   MY_SECRET (required)
     Your secret
 
+  REGION
+    Cloud region
+    Default: us-east-2
+
   ENVIRONMENT
     One of development, production or test
+    Allowed: development, production, testing
     Default: development
 
 + ./cli verify
@@ -67,11 +72,10 @@ missing required environment variable: MY_SECRET
 args: none
 
 environment variables:
-- $API_KEY = unset
-environment:
-- API_KEY=
-- ENVIRONMENT=development
-- MY_SECRET=there is no spoon
+- $API_KEY = 
+- $ENVIRONMENT = development
+- $MY_SECRET = there is no spoon
+- $REGION = us-east-2
 + ENVIRONMENT=production
 + MY_SECRET=safe-with-me
 + ./cli verify
@@ -81,8 +85,7 @@ environment:
 args: none
 
 environment variables:
-- $API_KEY = unset
-environment:
-- API_KEY=
-- ENVIRONMENT=production
-- MY_SECRET=safe-with-me
+- $API_KEY = 
+- $ENVIRONMENT = production
+- $MY_SECRET = safe-with-me
+- $REGION = us-east-2

--- a/spec/approvals/examples/multiline
+++ b/spec/approvals/examples/multiline
@@ -59,7 +59,7 @@ Examples:
 args: none
 
 environment variables:
-- $MULTI_VITAMIN = unset
+- $MULTI_VITAMIN = 
 + ./multi multiline -h
 multi multiline
 

--- a/spec/approvals/fixtures/environment-variables-initialize
+++ b/spec/approvals/fixtures/environment-variables-initialize
@@ -20,6 +20,7 @@ args:
 environment variables:
 - $API_KEY = must-be-available-in-initialize
 - $CONFIG_PATH = somepath
+- $NESTED_VAR = not-available-in-initialize
 + export API_KEY=override-value
 + API_KEY=override-value
 + ./cli

--- a/spec/approvals/fixtures/partials-extension
+++ b/spec/approvals/fixtures/partials-extension
@@ -104,4 +104,5 @@ args:
 - ${args[source]} = something
 
 environment variables:
-- $API_KEY = unset
+- $API_KEY = 
+- $DEFAULT_TARGET_LOCATION = 

--- a/support/schema/bashly.yml
+++ b/support/schema/bashly.yml
@@ -377,6 +377,20 @@ definitions:
       https://bashly.dannyb.co/configuration/environment-variable/#required
     type: boolean
     default: true
+  environment-variables-allowed-property:
+    title: allowed
+    description: |-
+      Valid values of the current environment variable
+      https://bashly.dannyb.co/configuration/environment-variable/#allowed
+    type: array
+    minLength: 1
+    uniqueItems: true
+    items:
+      description: A valid value of the current environment variable
+      type: string
+      minLength: 1
+      examples:
+        - production
   environment-variables-property:
     title: environment variables
     description: |-
@@ -403,6 +417,8 @@ definitions:
           $ref: '#/definitions/environment-variables-private-property'
         required:
           $ref: '#/definitions/environment-variables-required-property'
+        allowed:
+          $ref: '#/definitions/environment-variables-allowed-property'
       if:
         properties:
           required:
@@ -419,6 +435,8 @@ definitions:
             $ref: '#/definitions/environment-variables-private-property'
           required:
             $ref: '#/definitions/environment-variables-required-property'
+          allowed:
+            $ref: '#/definitions/environment-variables-allowed-property'
         patternProperties: *custom-properties
         additionalProperties: false
       else:


### PR DESCRIPTION
Fixes the `inspect_args` handling of environment variables, so that it is similar to the other things it prints. This is necessary to allow nested commands to print their own variables, and accumulate variables from their parent command.