### PR TITLE
Avoid rendering `inspect_args()` when generating for production env

### DIFF
--- a/lib/bashly/commands/generate.rb
+++ b/lib/bashly/commands/generate.rb
@@ -16,8 +16,8 @@ module Bashly
       option '-e --env ENV', <<~HELP
         Force the generation environment:
 
-        - production    generate a smaller script, without file markers
-        - development   generate with file markers
+        - development   default script output
+        - production    remove file marker comments and development functions
       HELP
 
       example 'bashly generate --force'

--- a/lib/bashly/views/command/master_script.gtx
+++ b/lib/bashly/views/command/master_script.gtx
@@ -4,7 +4,7 @@
 = render :version_command
 = render :usage
 = render :normalize_input
-= render :inspect_args
+= render :inspect_args unless Settings.production?
 = render :user_lib if user_lib.any?
 = render :command_functions
 = render :parse_requirements

--- a/spec/approvals/cli/generate/help
+++ b/spec/approvals/cli/generate/help
@@ -23,8 +23,8 @@ Options:
   -e --env ENV
     Force the generation environment:
     
-    - production    generate a smaller script, without file markers
-    - development   generate with file markers
+    - development   default script output
+    - production    remove file marker comments and development functions
 
   -h --help
     Show this help

--- a/spec/bashly/commands/generate_spec.rb
+++ b/spec/bashly/commands/generate_spec.rb
@@ -28,10 +28,11 @@ describe Commands::Generate do
       before { Settings.env = :production }
       after  { Settings.env = nil }
 
-      it 'generates a script without view markers' do
+      it 'generates a script without view markers or inspect_args function' do
         expect { subject.execute %w[generate] }.to output_approval('cli/generate/production-env-var')
         expect(File).to exist(cli_script)
         expect(cli_script_content).not_to include '# :'
+        expect(cli_script_content).not_to include 'inspect_args()'
       end
     end
 


### PR DESCRIPTION
cc #479, #480