### PR TITLE
Adjust docker image to be consistent with multiple cpu arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM dannyben/alpine-ruby
+FROM ruby:3.3.0-slim-bookworm
 
 ENV PS1 "\n\n>> bashly \W \$ "
 WORKDIR /app
 
-# Install pandoc to support manpage generation (`bashly render :mandoc docs`)
-RUN apk add --no-cache pandoc-cli
+ENV BASHLY_VERSION=1.1.6
+ENV RUBY_SYSTEM_VERSION=3.5.5
 
-RUN gem install bashly --version 1.1.6
+# Install pandoc to support manpage generation (`bashly render :mandoc docs`)
+RUN apt update -y  \
+    && apt install pandoc -y  \
+    && apt clean
+
+RUN gem install bashly --version $BASHLY_VERSION  \
+    && gem update --system $RUBY_SYSTEM_VERSION
 
 ENTRYPOINT ["bashly"]


### PR DESCRIPTION
After some experiments, I realized that the current image is locked for x86_64. A simple way to have multiple platforms is by using a more generic base image. This version is actually smaller than the original one as well. Old one 510MB vs 464MB new one