### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM dannyben/alpine-ruby
 
+ENV BASHLY_VERSION=1.1.6
 ENV PS1 "\n\n>> bashly \W \$ "
 WORKDIR /app
 
 # Install pandoc to support manpage generation (`bashly render :mandoc docs`)
 RUN apk add --no-cache pandoc-cli
 
-RUN gem install bashly --version 1.1.6
+RUN gem install bashly --version $BASHLY_VERSION && \
+    gem update --system
 
 ENTRYPOINT ["bashly"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   bash:
     build: .
+    command: bash
     <<: &default
       entrypoint: []
       image: dannyben/bashly
@@ -9,10 +10,7 @@ services:
     build: .
     image: dannyben/bashly
 
-  bashly-test:
-    <<: *default
-    command: bashly --version
-
   pandoc-test:
     <<: *default
-    command: pandoc --version
+    command: sh -c "pandoc --version | grep 'pandoc 3.1'"
+


### PR DESCRIPTION
- Update Dockerfile based on some insights from #485
- Tighten docker pandoc smoke test to ensure version 3.1.x