### PR TITLE
Update flag-args-with-dash test to validate #499

### DIFF
--- a/spec/approvals/fixtures/flag-args-with-dash
+++ b/spec/approvals/fixtures/flag-args-with-dash
@@ -16,3 +16,19 @@ args:
 args:
 - ${args[--force]} = 1
 - ${args[--options]} = --verbose --anything
++ BASHLY_COMPACT_SHORT_FLAGS=no
++ bundle exec bashly generate
+creating user files in src
+skipped src/root_command.sh (exists)
+created ./argflag
+run ./argflag --help to test your bash script
++ ./argflag -o -force
+# this file is located in 'src/root_command.sh'
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[--options]} = -force
++ ./argflag -o '-f -o'
+# this file is located in 'src/root_command.sh'
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[--options]} = -f -o

--- a/spec/fixtures/workspaces/flag-args-with-dash/README.md
+++ b/spec/fixtures/workspaces/flag-args-with-dash/README.md
@@ -5,4 +5,14 @@ starts with a dash - for example:
 --options '--verbose -v'
 ```
 
-Reference issue: https://github.com/DannyBen/bashly/issues/58
+Note that when it is expected that flag arguments will be in a form that
+resembles a collection of short flags (i.e. single hyphen followed by
+alphanumeric characters), for example `--options -abc`, then the compact flags
+feature should be disabled with `compact_short_flags: false` in the settings.
+
+See https://bashly.dannyb.co/usage/settings/#compact_short_flags
+
+Reference issues:
+
+- https://github.com/DannyBen/bashly/issues/58
+- https://github.com/DannyBen/bashly/issues/499

--- a/spec/fixtures/workspaces/flag-args-with-dash/test.sh
+++ b/spec/fixtures/workspaces/flag-args-with-dash/test.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# This fixture tests that alias command codes work properly
-# It is executed as part of the Runfile examples test
-# Reference issue: https://github.com/DannyBen/bashly/issues/16
-
 rm -f ./src/*.sh
 rm -f ./argflag
 
@@ -14,3 +10,10 @@ bundle exec bashly generate
 ./argflag -f -o
 ./argflag -o -f
 ./argflag -o '--verbose --anything' -f
+
+# if flag args are expected to look like a short flag collection, it is
+# necessary to disable `compact_short_flags` either in settings or environment
+# variable.
+BASHLY_COMPACT_SHORT_FLAGS=no bundle exec bashly generate
+./argflag -o -force
+./argflag -o '-f -o'


### PR DESCRIPTION
Ads a test for `./cli -a -bcd` where `-bcd` is expected to NOT be expanded as `-b -c -d`.

Closes #499