### PR TITLE
Add `Renderable#render_options` for `argument/case.gtx`

### DIFF
--- a/lib/bashly/concerns/renderable.rb
+++ b/lib/bashly/concerns/renderable.rb
@@ -2,7 +2,10 @@ require 'gtx'
 
 module Bashly
   module Renderable
-    def render(view)
+    attr_reader :render_options
+
+    def render(view, render_options = {})
+      @render_options = render_options
       GTX.render_file view_path(view), context: binding, filename: "#{views_subfolder}.#{view}"
     end
 

--- a/lib/bashly/views/argument/case.gtx
+++ b/lib/bashly/views/argument/case.gtx
@@ -1,0 +1,6 @@
+= view_marker
+
+condition = render_options[:index].zero? ? 'if' : 'elif'
+> {{ condition }} [[ -z ${args['{{ name }}']+x} ]]; then
+>   args['{{ name }}']=$1
+>   shift

--- a/lib/bashly/views/argument/case_repeatable.gtx
+++ b/lib/bashly/views/argument/case_repeatable.gtx
@@ -1,0 +1,25 @@
+= view_marker
+
+condition = render_options[:index].zero? ? 'if' : 'elif'
+
+if render_options[:index] == 0
+  > escaped="$(printf '%q' "$1")"
+end
+
+> {{ condition }} [[ -z ${args['{{ name }}']+x} ]]; then
+if repeatable
+  >   args['{{ name }}']="$escaped"
+  if unique
+    >   unique_lookup["{{ name }}:$escaped"]=1
+    > elif [[ -z "${unique_lookup["{{ name }}:$escaped"]:-}" ]]; then
+    >   args['{{ name }}']="${args['{{ name }}']} $escaped"
+    >   unique_lookup["{{ name }}:$escaped"]=1
+  else
+    > else
+    >   args['{{ name }}']="${args['{{ name }}']} $escaped"
+  end
+
+else
+  >   args['{{ name }}']="$1"
+
+end

--- a/lib/bashly/views/command/parse_requirements_case_catch_all.gtx
+++ b/lib/bashly/views/command/parse_requirements_case_catch_all.gtx
@@ -1,13 +1,8 @@
 = view_marker
 
 if args.any?
-  condition = "if"
-  args.each do |arg|
-    > {{ condition }} [[ -z ${args['{{ arg.name }}']+x} ]]; then
-    >   args['{{ arg.name }}']=$1
-    >   shift
-    
-    condition = "elif"
+  args.each_with_index do |arg, index|
+    = arg.render :case, index: index
   end
 
   > else

--- a/lib/bashly/views/command/parse_requirements_case_repeatable.gtx
+++ b/lib/bashly/views/command/parse_requirements_case_repeatable.gtx
@@ -1,28 +1,7 @@
 = view_marker
 
-condition = "if"
 args.each_with_index do |arg, index|
-  if index == 0
-    > escaped="$(printf '%q' "$1")"
-  end
-  > {{ condition }} [[ -z ${args['{{ arg.name }}']+x} ]]; then
-  if arg.repeatable
-    >   args['{{ arg.name }}']="$escaped"
-    if arg.unique
-      >   unique_lookup["{{ arg.name }}:$escaped"]=1
-      > elif [[ -z "${unique_lookup["{{ arg.name }}:$escaped"]:-}" ]]; then
-      >   args['{{ arg.name }}']="${args['{{ arg.name }}']} $escaped"
-      >   unique_lookup["{{ arg.name }}:$escaped"]=1
-    else
-      > else
-      >   args['{{ arg.name }}']="${args['{{ arg.name }}']} $escaped"
-    end
-
-  else
-    >   args['{{ arg.name }}']="$1"
-
-  end
-  condition = "elif"
+  = arg.render :case_repeatable, index: index
 end
 
 > fi

--- a/lib/bashly/views/command/parse_requirements_case_simple.gtx
+++ b/lib/bashly/views/command/parse_requirements_case_simple.gtx
@@ -1,13 +1,8 @@
 = view_marker
 
 if args.any?
-  condition = "if"
-  args.each do |arg|
-    > {{ condition }} [[ -z ${args['{{ arg.name }}']+x} ]]; then
-    >   args['{{ arg.name }}']=$1
-    >   shift
-
-    condition = "elif"
+  args.each_with_index do |arg, index|
+    = arg.render :case, index: index
   end
 
   > else


### PR DESCRIPTION
This PR adds the ability to pass arbitrary options to the `render` method.

It is needed (and now implemented) to extract the argument case template from the command context, to the argument context, where it belongs.
