### PR TITLE
Sanitize percent signs in help messages

### DIFF
--- a/lib/bashly/extensions/string.rb
+++ b/lib/bashly/extensions/string.rb
@@ -1,6 +1,6 @@
 class String
   def sanitize_for_print
-    gsub("\n", '\\n').gsub('"', '\"').gsub('`', '\\\\`')
+    gsub("\n", '\\n').gsub('"', '\"').gsub('`', '\\\\`').gsub('%', '%%')
   end
 
   def for_markdown

--- a/spec/bashly/extensions/string_spec.rb
+++ b/spec/bashly/extensions/string_spec.rb
@@ -1,9 +1,9 @@
 describe String do
   describe '#sanitize_for_print' do
-    subject { "this is\na \"new line\" with `backticks`" }
+    subject { "this is\na \"new line\" with `backticks` and % symbol" }
 
     it 'escapes newlines and quotes' do
-      expect(subject.sanitize_for_print).to eq 'this is\\na \"new line\" with \`backticks\`'
+      expect(subject.sanitize_for_print).to eq 'this is\\na \"new line\" with \`backticks\` and %% symbol'
     end
   end
 


### PR DESCRIPTION
This PR makes it so % symbols in help messages do not cause an implosion.

Before this PR, the following YAML failed. 

```yaml
name: cli

args:
- name: factor
  help: Provide % of change
- name: template
  help: Any string. Use %h or %H to specofy hostname
```

and the only way to make it work prior to this PR was to use `%%` instead of `%` - which then broke other uses of the string, such as generating man pages.