### PR TITLE
Fix input normalization to ignore anything after the double dash (--) operator

### DIFF
--- a/examples/catch-all-advanced/test.sh
+++ b/examples/catch-all-advanced/test.sh
@@ -12,7 +12,13 @@ bashly generate
 ./cli download -h
 ./cli download source
 ./cli download source target
-./cli download source target and --additional stuff
+./cli download source target --force
+
+# when passing arbitrary arguments that start with a hyphen...
+./cli download source target --force -abc --option=value
+
+# ...use the double dash (--) operator to disable input normalization
+./cli download source target --force -- -abc --option=value
 
 ./cli upload -h
 ./cli upload

--- a/lib/bashly/views/command/normalize_input.gtx
+++ b/lib/bashly/views/command/normalize_input.gtx
@@ -2,6 +2,7 @@
 
 > normalize_input() {
 >   local arg flags passthru
+>   passthru=false
 > 
 >   while [[ $# -gt 0 ]]; do
 >     arg="$1"

--- a/lib/bashly/views/command/normalize_input.gtx
+++ b/lib/bashly/views/command/normalize_input.gtx
@@ -1,11 +1,13 @@
 = view_marker
 
 > normalize_input() {
->   local arg flags
+>   local arg flags passthru
 > 
 >   while [[ $# -gt 0 ]]; do
 >     arg="$1"
->     if [[ $arg =~ ^(--[a-zA-Z0-9_\-]+)=(.+)$ ]]; then
+>     if [[ $passthru == true ]]; then
+>       input+=("$arg")
+>     elif [[ $arg =~ ^(--[a-zA-Z0-9_\-]+)=(.+)$ ]]; then
 >       input+=("${BASH_REMATCH[1]}")
 >       input+=("${BASH_REMATCH[2]}")
 >     elif [[ $arg =~ ^(-[a-zA-Z0-9])=(.+)$ ]]; then
@@ -20,6 +22,9 @@ if Settings.compact_short_flags
 >       done
 end
 
+>     elif [[ "$arg" == "--" ]]; then
+>       passthru=true
+>       input+=("$arg")
 >     else
 >       input+=("$arg")
 >     fi

--- a/spec/approvals/examples/catch-all-advanced
+++ b/spec/approvals/examples/catch-all-advanced
@@ -59,19 +59,43 @@ args:
 args:
 - ${args[source]} = source
 - ${args[target]} = target
-+ ./cli download source target and --additional stuff
++ ./cli download source target --force
 # this file is located in 'src/download_command.sh'
 # code for 'cli download' goes here
 # you can edit it freely and regenerate (it will not be overwritten)
 args:
+- ${args[--force]} = 1
+- ${args[source]} = source
+- ${args[target]} = target
++ ./cli download source target --force -abc --option=value
+# this file is located in 'src/download_command.sh'
+# code for 'cli download' goes here
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[--force]} = 1
 - ${args[source]} = source
 - ${args[target]} = target
 
 other_args:
-- ${other_args[*]} = and --additional stuff
-- ${other_args[0]} = and
-- ${other_args[1]} = --additional
-- ${other_args[2]} = stuff
+- ${other_args[*]} = -a -b -c --option value
+- ${other_args[0]} = -a
+- ${other_args[1]} = -b
+- ${other_args[2]} = -c
+- ${other_args[3]} = --option
+- ${other_args[4]} = value
++ ./cli download source target --force -- -abc --option=value
+# this file is located in 'src/download_command.sh'
+# code for 'cli download' goes here
+# you can edit it freely and regenerate (it will not be overwritten)
+args:
+- ${args[--force]} = 1
+- ${args[source]} = source
+- ${args[target]} = target
+
+other_args:
+- ${other_args[*]} = -abc --option=value
+- ${other_args[0]} = -abc
+- ${other_args[1]} = --option=value
 + ./cli upload -h
 cli upload - Upload a file
 


### PR DESCRIPTION
cc #510

In a script with `catch_all`, arguments that follow the `--` operator should be passed as is, without normalization.

Given this YAML:

```yaml
name: cli
catch_all:
  label: arguments
  required: true
```

This command:

```
./cli -123 -- -abc --key=value
```

was creating an unexpected result

```
${other_args[*]} = -1 -2 -3 -a -b -c --key value
```

With this PR, the result is as expected:

```
${other_args[*]} = -1 -2 -3 -abc --key=value
```

Arguments before the `--` are normalized, and arguments after it stay in tact.