### PR TITLE
Update completions library to consider private visibility setting

### DIFF
--- a/lib/bashly/concerns/completions.rb
+++ b/lib/bashly/concerns/completions.rb
@@ -29,7 +29,7 @@ module Bashly
           end
         end
 
-        public_commands.each do |command|
+        visible_commands.each do |command|
           result.merge! command.completion_data(with_version: false)
         end
 
@@ -62,7 +62,7 @@ module Bashly
       end
 
       def completion_flag_names
-        public_flags.map(&:name) + public_flags.map(&:short)
+        visible_flags.map(&:name) + public_flags.map(&:short)
       end
 
       def completion_allowed_args
@@ -73,7 +73,7 @@ module Bashly
         trivial_flags = %w[--help -h]
         trivial_flags += %w[--version -v] if with_version
         all = (
-          public_command_aliases + trivial_flags +
+          visible_command_aliases + trivial_flags +
           completion_flag_names + completion_allowed_args
         )
 

--- a/lib/bashly/script/introspection/commands.rb
+++ b/lib/bashly/script/introspection/commands.rb
@@ -94,6 +94,17 @@ module Bashly
         def public_command_aliases
           public_commands.map(&:aliases).flatten
         end
+
+        # Returns only public commands, or both public and private commands
+        # if Settings.private_reveal_key is set
+        def visible_commands
+          Settings.private_reveal_key ? commands : public_commands
+        end
+
+        # Returns a full list of the visible Command names and aliases combined
+        def visible_command_aliases
+          visible_commands.map(&:aliases).flatten
+        end
       end
     end
   end

--- a/lib/bashly/script/introspection/flags.rb
+++ b/lib/bashly/script/introspection/flags.rb
@@ -42,6 +42,12 @@ module Bashly
           flags.any? { |f| f.short == flag }
         end
 
+        # Returns only public flags, or both public and private flags if
+        # Settings.private_reveal_key is set
+        def visible_flags
+          Settings.private_reveal_key ? flags : public_flags
+        end
+
         # Returns an array of all the flags with a whitelist arg
         def whitelisted_flags
           flags.select(&:allowed)

--- a/spec/bashly/script/introspection/commands_spec.rb
+++ b/spec/bashly/script/introspection/commands_spec.rb
@@ -109,11 +109,49 @@ describe Script::Introspection::Commands do
     end
   end
 
-  describe '#public_commands_aliases' do
+  describe '#public_command_aliases' do
     let(:fixture) { :private_commands }
 
     it 'returns an array of command aliases of public subcommands' do
       expect(subject.public_command_aliases).to eq %w[connect c]
+    end
+  end
+
+  describe '#visible_commands' do
+    let(:fixture) { :private_commands }
+
+    it 'returns public commands only (same as #public_commands)' do
+      expect(subject.visible_commands.size).to eq 1
+      expect(subject.visible_commands.first.name).to eq 'connect'
+    end
+
+    context 'when Settings.private_reveal_key is set' do
+      before { Settings.private_reveal_key = 'SHOW' }
+      after { Settings.private_reveal_key = nil }
+
+      it 'returns all commands (same as #commands)' do
+        expect(subject.visible_commands.size).to eq 3
+        expect(subject.visible_commands[1].name).to eq 'connect-ftp'
+      end
+    end
+  end
+
+  describe '#visible_command_aliases' do
+    let(:fixture) { :private_commands }
+
+    it 'returns an array of command aliases of public subcommands' do
+      expect(subject.visible_command_aliases).to eq %w[connect c]
+    end
+
+    context 'when Settings.private_reveal_key is set' do
+      before { Settings.private_reveal_key = 'SHOW' }
+      after { Settings.private_reveal_key = nil }
+
+      it 'returns an array of command aliases of all subcommands' do
+        expect(subject.visible_command_aliases).to eq %w[
+          connect c connect-ftp cf connect-ssh cs
+        ]
+      end
     end
   end
 end

--- a/spec/bashly/script/introspection/flags_spec.rb
+++ b/spec/bashly/script/introspection/flags_spec.rb
@@ -91,6 +91,25 @@ describe Script::Introspection::Flags do
     end
   end
 
+  describe '#visible_flags' do
+    let(:fixture) { :private_flags }
+
+    it 'returns public flags only (same as #public_flags)' do
+      expect(subject.visible_flags.size).to eq 1
+      expect(subject.visible_flags.first.long).to eq '--new'
+    end
+
+    context 'when Settings.private_reveal_key is set' do
+      before { Settings.private_reveal_key = 'SHOW' }
+      after { Settings.private_reveal_key = nil }
+
+      it 'returns all flags (same as #flags)' do
+        expect(subject.visible_flags.size).to eq 2
+        expect(subject.visible_flags.first.long).to eq '--legacy'
+      end
+    end
+  end
+
   describe '#whitelisted_flags' do
     let(:fixture) { :whitelist }
 

--- a/spec/fixtures/script/commands.yml
+++ b/spec/fixtures/script/commands.yml
@@ -437,7 +437,7 @@
     alias: cf
     private: true
   - name: connect-ssh
-    alias: cf
+    alias: cs
     private: true
 
 :private_flags:


### PR DESCRIPTION
This PR adds a few additional introspection methods to `Flag` and `Command`. These new methods return either public or public + private elements, based on `Settings.private_reveal_key`.

These methods are needed for rendering completions, mandoc and markdown documentation.

