### PR TITLE
Update mandoc/markdown library to consider private visibility setting

### DIFF
--- a/lib/bashly/concerns/completions.rb
+++ b/lib/bashly/concerns/completions.rb
@@ -62,7 +62,7 @@ module Bashly
       end
 
       def completion_flag_names
-        visible_flags.map(&:name) + public_flags.map(&:short)
+        visible_flags.map(&:name) + visible_flags.map(&:short)
       end
 
       def completion_allowed_args

--- a/lib/bashly/libraries/render/mandoc/mandoc.gtx
+++ b/lib/bashly/libraries/render/mandoc/mandoc.gtx
@@ -43,7 +43,7 @@ if extensible
 end
 >
 
-if public_commands.any?
+if visible_commands.any?
   grouped_commands.each do |group, commands|
     > {{ group.gsub(/:$/, '').upcase }}
     > ==================================================
@@ -150,11 +150,11 @@ if dependencies.any?
   end
 end
 
-if public_environment_variables.any?
+if visible_environment_variables.any?
   > ENVIRONMENT VARIABLES
   > ==================================================
   >
-  public_environment_variables.each do |environment_variable|
+  visible_environment_variables.each do |environment_variable|
     > {{ environment_variable.name.upcase }}
     > --------------------------------------------------
     >
@@ -186,7 +186,7 @@ end
 
 see_also = []
 see_also << parents.first if parents.any?
-see_also += public_commands.map { |x| x.full_name.to_hyphen } if public_commands.any?
+see_also += visible_commands.map { |x| x.full_name.to_hyphen } if visible_commands.any?
 see_also += x_mandoc_see_also if x_mandoc_see_also && x_mandoc_see_also.is_a?(Array)
 see_also.map! do |item|
   item.match(/(.+)(\(\d\))/) ? "**#{$1}**#{$2}" : "**#{item}**(1)"

--- a/lib/bashly/libraries/render/markdown/markdown.gtx
+++ b/lib/bashly/libraries/render/markdown/markdown.gtx
@@ -62,10 +62,10 @@ end
 
 # === Environment Variables
 
-if public_environment_variables.any?
+if visible_environment_variables.any?
   > ## Environment Variables
   >
-  public_environment_variables.each do |environment_variable|
+  visible_environment_variables.each do |environment_variable|
     attributes = environment_variable.required || environment_variable.default
 
     > #### *{{ environment_variable.name.upcase }}*

--- a/lib/bashly/script/introspection/commands.rb
+++ b/lib/bashly/script/introspection/commands.rb
@@ -72,12 +72,12 @@ module Bashly
         def grouped_commands
           result = {}
 
-          public_commands.each do |command|
+          visible_commands.each do |command|
             result[command.group_string] ||= []
             result[command.group_string] << command
             next unless command.expose
 
-            command.public_commands.each do |subcommand|
+            command.visible_commands.each do |subcommand|
               result[command.group_string] << subcommand
             end
           end

--- a/lib/bashly/script/introspection/environment_variables.rb
+++ b/lib/bashly/script/introspection/environment_variables.rb
@@ -31,6 +31,12 @@ module Bashly
           environment_variables.select(&:validate)
         end
 
+        # Returns only public environment variables, or both public and private
+        # environment variables if Settings.private_reveal_key is set
+        def visible_environment_variables
+          Settings.private_reveal_key ? environment_variables : public_environment_variables
+        end
+
         # Returns an array of all the environment_variables with a whitelist arg
         def whitelisted_environment_variables
           environment_variables.select(&:allowed)

--- a/lib/bashly/views/argument/usage.gtx
+++ b/lib/bashly/views/argument/usage.gtx
@@ -4,7 +4,7 @@
 > printf "{{ help.wrap(76).indent(4).sanitize_for_print }}\n"
 
 if allowed
-  > printf "    %s\n" "{{ strings[:allowed] % { values: allowed.join(', ') } }}\n"
+  > printf "    %s\n" "{{ strings[:allowed] % { values: allowed.join(', ') } }}"
 end
 
 if default

--- a/spec/README.md
+++ b/spec/README.md
@@ -18,10 +18,21 @@ Some specs have tags for convenience:
 - `:stable` - specs of features that rarely change
 - `:noci` - specs that are disabled in CI
 
-For example, to run only specs that are not :slow and not :stable, run:
+## Useful respec commands
+
 
 ```bash
+# smoke test; run only specs that are not :slow and not :stable
 $ respec tagged ~stable ~slow
+
+# test examples only
+$ respec only examples
+
+# test a specific example only
+$ EXAMPLE=whitelist respec only examples
+
+# test only specs that changed recently, and repeat on change
+$ respec refactor  # or respec r
 ```
 
 ## Notes about Example Tests

--- a/spec/approvals/examples/command-private
+++ b/spec/approvals/examples/command-private
@@ -14,7 +14,7 @@ Usage:
   cli --version | -v
 
 Commands:
-  connect   Connect to the metaverse
+  connect       Connect to the metaverse
 
 + ./cli -h
 cli - Sample application with private commands
@@ -25,7 +25,7 @@ Usage:
   cli --version | -v
 
 Commands:
-  connect   Connect to the metaverse
+  connect       Connect to the metaverse
 
 Options:
   --help, -h


### PR DESCRIPTION
Update mandoc and markdown rendering libraries to consider visible elements instead of purely public elements.
This means these renderers will also include private commands, if `private_reveal_key` is set in the settings.