### PR TITLE
Fix docker multi-arch build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM dannyben/alpine-ruby:3.3.3
 
-ENV BASHLY_VERSION=1.2.2
 ENV PS1="\n\n>> bashly \W \$ "
+ENV BASHLY_VERSION=1.2.2
+
 WORKDIR /app
 
 # Install pandoc to support manpage generation (`bashly render :mandoc docs`)
 RUN apk add --no-cache pandoc-cli
 
-RUN gem install bashly --version $BASHLY_VERSION && \
-    gem update --system
+RUN gem install bashly --version $BASHLY_VERSION
+
+VOLUME /app
 
 ENTRYPOINT ["bashly"]

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -14,4 +14,5 @@ WORKDIR /app
 RUN rm -rf /bashly
 
 VOLUME /app
+
 ENTRYPOINT ["bashly"]


### PR DESCRIPTION
The docker multi-arch build had issues:

1. It was using a base image that was not multi-arch. Now using dannyben/alpine-ruby:3.3.3 which is multi-arch.
2. After the change, the edge version was building properly, but the main Dockerfile was not. The build process just hang at some random point for over 30 minutes.
3. This PR made it so the build works - not sure what was the particular change that made it, perhaps the removal of `gem update --system`.

