### PR TITLE
Refactor `command.variables` to a new `Variable` object

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,10 @@ Naming/AccessorMethodName:
     - 'lib/bashly/concerns/indentation_helper.rb'
 
 # FIXME: The `Command` class is too long
-Metrics/ClassLength: { Exclude: [lib/bashly/script/command.rb] }
+Metrics/ClassLength:
+  Exclude: 
+    - lib/bashly/script/command.rb
+    - lib/bashly/config_validator.rb
 
 # Allow irregular filenames in some cases
 RSpec/SpecFilePathFormat:

--- a/lib/bashly.rb
+++ b/lib/bashly.rb
@@ -22,13 +22,13 @@ module Bashly
   module Script
     autoloads 'bashly/script', %i[
       Argument Base CatchAll Command Dependency EnvironmentVariable Flag
-      Wrapper
+      Variable Wrapper
     ]
 
     module Introspection
       autoloads 'bashly/script/introspection', %i[
         Arguments Commands Dependencies EnvironmentVariables Examples Flags
-        Visibility
+        Variables Visibility
       ]
     end
   end

--- a/lib/bashly/script/command.rb
+++ b/lib/bashly/script/command.rb
@@ -8,6 +8,7 @@ module Bashly
       include Introspection::EnvironmentVariables
       include Introspection::Examples
       include Introspection::Flags
+      include Introspection::Variables
       include Introspection::Visibility
 
       class << self

--- a/lib/bashly/script/introspection/variables.rb
+++ b/lib/bashly/script/introspection/variables.rb
@@ -1,0 +1,16 @@
+module Bashly
+  module Script
+    module Introspection
+      module Variables
+        # Returns an array of Variable objects
+        def variables
+          return [] unless options['variables']
+
+          options['variables'].map do |options|
+            Variable.new options
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bashly/script/variable.rb
+++ b/lib/bashly/script/variable.rb
@@ -1,0 +1,11 @@
+module Bashly
+  module Script
+    class Variable < Base
+      class << self
+        def option_keys
+          @option_keys ||= %i[name value]
+        end
+      end
+    end
+  end
+end

--- a/lib/bashly/views/command/variables.gtx
+++ b/lib/bashly/views/command/variables.gtx
@@ -1,30 +1,5 @@
 = view_marker
 
 variables.each do |var|
-  case var['value']
-  when Array
-    if var['value'].empty?
-    > declare -a {{ var['name'] }}=()
-    else
-    > declare -a {{ var['name'] }}=(
-      var['value'].each do |v|
-    >   "{{ v }}"
-      end
-    > )
-    end
-  when Hash
-    if var['value'].empty?
-    > declare -A {{ var['name'] }}=()
-    else
-    > declare -A {{ var['name'] }}=(
-      var['value'].each do |k, v|
-    >   ["{{ k }}"]="{{ v }}"
-      end
-    > )
-    end
-  when String, NilClass
-    > {{ var['name'] }}="{{ var['value'] }}"
-  else
-    > {{ var['name'] }}={{ var['value'] }}
-  end
+  = var.render(:definition)
 end

--- a/lib/bashly/views/variable/definition.gtx
+++ b/lib/bashly/views/variable/definition.gtx
@@ -1,0 +1,28 @@
+= view_marker
+
+case value
+when Array
+  if value.empty?
+  > declare -a {{ name }}=()
+  else
+  > declare -a {{ name }}=(
+    value.each do |v|
+  >   "{{ v }}"
+    end
+  > )
+  end
+when Hash
+  if value.empty?
+  > declare -A {{ name }}=()
+  else
+  > declare -A {{ name }}=(
+    value.each do |k, v|
+  >   ["{{ k }}"]="{{ v }}"
+    end
+  > )
+  end
+when String, NilClass
+  > {{ name }}="{{ value }}"
+else
+  > {{ name }}={{ value }}
+end

--- a/spec/bashly/script/introspection/variables_spec.rb
+++ b/spec/bashly/script/introspection/variables_spec.rb
@@ -1,0 +1,17 @@
+describe Script::Introspection::Variables, :focus do
+  subject do
+    result = Script::Command.new fixtures[fixture]
+    result.parents = result.options['parents']
+    result
+  end
+
+  let(:fixtures) { load_fixture 'script/commands' }
+  let(:fixture) { :variables }
+
+  describe '#variables' do
+    it 'returns an array of Variable objects' do
+      expect(subject.variables).to be_an Array
+      expect(subject.variables).to all(be_a Script::Variable)
+    end
+  end
+end

--- a/spec/bashly/script/introspection/variables_spec.rb
+++ b/spec/bashly/script/introspection/variables_spec.rb
@@ -1,4 +1,4 @@
-describe Script::Introspection::Variables, :focus do
+describe Script::Introspection::Variables do
   subject do
     result = Script::Command.new fixtures[fixture]
     result.parents = result.options['parents']

--- a/spec/fixtures/script/commands.yml
+++ b/spec/fixtures/script/commands.yml
@@ -489,6 +489,21 @@
       repeatable: true
       unique: true
 
+:variables:
+  name: get
+  variables:
+  - name: debug
+    value: true
+  - name: url
+    value: http://hello.com
+  - name: number
+    value: 123
+  - name: array
+    value: [one, two]
+  - name: hash
+    value: { one: 1, two: 2 }
+  - name: empty
+
 :whitelist:
   name: cli
   args:


### PR DESCRIPTION
Make `command.variables` return an array of `Variable` objects, similar to `command.environment_variables`.