### PR TITLE
Update version specifications for all dependencies

### DIFF
--- a/bashly.gemspec
+++ b/bashly.gemspec
@@ -16,21 +16,17 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.1'
 
   s.add_dependency 'colsole', '>= 0.8.1', '< 2'
-  s.add_dependency 'completely', '~> 0.6.1'
+  s.add_dependency 'completely', '>= 0.6.1', '< 0.8'
   s.add_dependency 'filewatcher', '~> 2.0'
-  s.add_dependency 'gtx', '~> 0.1'
-  s.add_dependency 'lp', '~> 0.2'
-  s.add_dependency 'mister_bin', '~> 0.7'
-  s.add_dependency 'requires', '~> 1.1.0'
-  s.add_dependency 'tty-markdown', '~> 0.7'
+  s.add_dependency 'gtx', '~> 0.1.1'
+  s.add_dependency 'lp', '~> 0.2.0'
+  s.add_dependency 'mister_bin', '~> 0.7.0'
+  s.add_dependency 'requires', '~> 1.1'
+  s.add_dependency 'tty-markdown', '~> 0.7.2'
 
   # Sub-dependenceis (Ruby 3.3.5 warnings)
   s.add_dependency 'logger', '>= 1', '< 3'    # required by filewatcher
   s.add_dependency 'ostruct', '>= 0', '< 2'   # required by json
-
-  # Ruby 3.0 comes with Psych 3.3.0, which does not have the `unsafe_load`
-  # ref: https://github.com/ruby/psych/commit/cb50aa8d3fb8be01897becff77b4922b12a0ab4c
-  s.add_dependency 'psych', '>= 3.3.2', '< 7'
 
   s.metadata = {
     'bug_tracker_uri'       => 'https://github.com/DannyBen/bashly/issues',

--- a/spec/approvals/examples/dependencies-alt
+++ b/spec/approvals/examples/dependencies-alt
@@ -14,4 +14,4 @@ args: none
 deps:
 - ${deps[git]} = /usr/bin/git
 - ${deps[http_client]} = /usr/bin/curl
-- ${deps[ruby]} = /home/vagrant/.rbenv/versions/3.3.5/bin/ruby
+- ${deps[ruby]} = /home/vagrant/.rbenv/versions/3.3.6/bin/ruby


### PR DESCRIPTION
Update gemspec dependency versions, with these rules:

1. With 0.x gems - assume the minor version may introduce breaking changes, so require `~> 0.x.y`
2. With 1.x gems - assume breaking changes can only be introduced in major version, so require `~> 1.x`
3. In preparation for completely v0.7.0, allow 'completely', '>= 0.6.1', '< 0.8'