### PR TITLE
Remove `other_args` declaration if it is no used

### DIFF
--- a/lib/bashly/script/introspection/commands.rb
+++ b/lib/bashly/script/introspection/commands.rb
@@ -2,6 +2,7 @@ module Bashly
   module Script
     module Introspection
       module Commands
+        # Returns true if the command or any of its descendants has `catch_all`
         def catch_all_used_anywhere?
           deep_commands(include_self: true).any? { |x| x.catch_all.enabled? }
         end

--- a/lib/bashly/script/introspection/commands.rb
+++ b/lib/bashly/script/introspection/commands.rb
@@ -2,6 +2,10 @@ module Bashly
   module Script
     module Introspection
       module Commands
+        def catch_all_used_anywhere?
+          deep_commands(include_self: true).any? { |x| x.catch_all.enabled? }
+        end
+
         # Returns a full list of the Command names and aliases combined
         def command_aliases
           commands.map(&:aliases).flatten

--- a/lib/bashly/views/command/inspect_args.gtx
+++ b/lib/bashly/views/command/inspect_args.gtx
@@ -11,6 +11,8 @@
 >     echo args: none
 >   fi
 > 
+
+if catch_all_used_anywhere?
 >   if ((${#other_args[@]})); then
 >     echo
 >     echo other_args:
@@ -20,6 +22,8 @@
 >     done
 >   fi
 >
+end
+
 if Settings.enabled? :deps_array
   >   if ((${#deps[@]})); then
   >     readarray -t sorted_keys < <(printf '%s\n' "${!deps[@]}" | sort)
@@ -31,6 +35,7 @@ if Settings.enabled? :deps_array
   >   fi
   >
 end
+
 if Settings.enabled? :env_var_names_array
   >   if ((${#env_var_names[@]})); then
   >     readarray -t sorted_names < <(printf '%s\n' "${env_var_names[@]}" | sort)

--- a/lib/bashly/views/command/run.gtx
+++ b/lib/bashly/views/command/run.gtx
@@ -2,25 +2,34 @@
 
 > run() {
 >   declare -g -A args=()
+unless Settings.enabled? :inspect_args
+  >   # shellcheck disable=SC2034
+end
+>   declare -g -a other_args=()
+
 if Settings.enabled? :deps_array
   >   declare -g -A deps=()
 end
->   declare -g -a other_args=()
+
 if Settings.enabled? :env_var_names_array
   >   declare -g -a env_var_names=()
 end
+
 >   declare -g -a input=()
+
 if has_unique_args_or_flags?
   >   declare -g -A unique_lookup=()
 end
+
 >   normalize_input "$@"
 >   parse_requirements "${input[@]}"
+
 if user_file_exist?('before')
   >   before_hook
 end
+
 > 
 >   case "$action" in
-
 deep_commands.each do |command|
   >     "{{ command.action_name }}") {{ command.function_name }}_command ;;
 end

--- a/lib/bashly/views/command/run.gtx
+++ b/lib/bashly/views/command/run.gtx
@@ -2,10 +2,10 @@
 
 > run() {
 >   declare -g -A args=()
-unless Settings.enabled? :inspect_args
-  >   # shellcheck disable=SC2034
+
+if catch_all_used_anywhere?
+  >   declare -g -a other_args=()
 end
->   declare -g -a other_args=()
 
 if Settings.enabled? :deps_array
   >   declare -g -A deps=()


### PR DESCRIPTION
When `inspect_args` function is disbaled (e.g. when `env = production`), and there is no use for `other_args` (`catch_all` is not used), then shellcheck triggers a warning on this line:

```bash
run() {
  # ...
  declare -g -a other_args=()
  # ...
}
```

This PR:

1. Adds a `Command#catch_all_used_anywhere?` method that checks if the command itself or any of its descendants is using `catch_all`
2. Adds a condition check that uses this method before rendering the `other_args` declaration.


