### PR TITLE
Fix view markers for user files

### DIFF
--- a/lib/bashly/concerns/renderable.rb
+++ b/lib/bashly/concerns/renderable.rb
@@ -32,7 +32,7 @@ module Bashly
         ''
       end
 
-      Settings.production? ? content : "#{view_marker path}\n#{content}"
+      Settings.enabled?(:view_markers) ? "#{view_marker path}\n#{content}" : content
     end
 
     # Returns a path to a file in the user's source_dir. The file argument

--- a/lib/bashly/views/command/parse_requirements_while.gtx
+++ b/lib/bashly/views/command/parse_requirements_while.gtx
@@ -40,4 +40,4 @@ end
 > 
 >   esac
 > done
-
+>

--- a/lib/bashly/views/command/required_args_filter.gtx
+++ b/lib/bashly/views/command/required_args_filter.gtx
@@ -7,6 +7,7 @@ if required_args.any?
     = render(:examples_on_error).indent 2
     >   exit 1
     > fi
+    >
   end
 
   >


### PR DESCRIPTION
View markers in user files were still using the `if Settings.production?` condition instead of the new `Settings.enabled?(:view_markers)` condition, which caused the view marker to not be rendered even if the user requested it with `enable_view_markers` setting.