### PR TITLE
Add support for declaring aliases for internal global variables

### DIFF
--- a/lib/bashly/libraries/settings/settings.yml
+++ b/lib/bashly/libraries/settings/settings.yml
@@ -110,3 +110,18 @@ enable_view_markers: development
 enable_inspect_args: development
 enable_deps_array: always
 enable_env_var_names_array: always
+
+
+#-------------------------------------------------------------------------------
+# SCRIPTING OPTIONS
+#-------------------------------------------------------------------------------
+
+# These are the public global variables available for use in your partial
+# scripts. Adding a new name here will create a reference variable using
+# `declare -gn`, allowing you to access the original variable under the new
+# name in addition to its original name.
+var_aliases:
+  args: ~
+  other_args: ~
+  deps: ~
+  env_var_names: ~

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -22,7 +22,8 @@ module Bashly
         :strict,
         :tab_indent,
         :target_dir,
-        :usage_colors
+        :usage_colors,
+        :var_aliases
       )
 
       def commands_dir
@@ -131,6 +132,10 @@ module Bashly
 
       def usage_colors
         @usage_colors ||= get :usage_colors
+      end
+
+      def var_aliases
+        @var_aliases ||= get :var_aliases
       end
 
     private

--- a/lib/bashly/views/command/run.gtx
+++ b/lib/bashly/views/command/run.gtx
@@ -21,6 +21,13 @@ if has_unique_args_or_flags?
   >   declare -g -A unique_lookup=()
 end
 
+>
+Settings.var_aliases.each do |original, refname|
+  if refname
+    >   declare -gn {{ refname }}={{ original }}
+  end
+end
+>
 >   normalize_input "$@"
 >   parse_requirements "${input[@]}"
 


### PR DESCRIPTION
cc #586, #581 

This PR adds these settings:

```yaml
var_aliases:
  args: ~
  other_args: ~
  deps: ~
  env_var_names: ~
```

which will declare aliases using `declare -gn` to allow, for example, to use `$ARGS` instead of `$args`, or `$catch_all` instead of `$other_args`.



