### PR TITLE
fix(colors): only print colors if NO_COLOR is non-empty string

### DIFF
--- a/lib/bashly/libraries/colors/colors.sh
+++ b/lib/bashly/libraries/colors/colors.sh
@@ -13,7 +13,7 @@
 print_in_color() {
   local color="$1"
   shift
-  if [[ -z ${NO_COLOR+x} ]]; then
+  if [[ "${NO_COLOR:-}" == "" ]]; then
     printf "$color%b\e[0m\n" "$*"
   else
     printf "%b\n" "$*"


### PR DESCRIPTION
from <https://no-color.org/>:

> Command-line software which adds ANSI color to its output by default
> should check for a NO_COLOR environment variable that, when present
> and **not an empty string** (regardless of its value), prevents the
> addition of ANSI color.

(emphasis mine)

if `NO_COLOR` is an empty string, color should still be printed.

```bash
./my-cli  # print color
NO_COLOR=1 ./my-cli  # don't print color
NO_COLOR=0 ./my-cli  # don't print color
NO_COLOR=whatever ./my-cli  # don't print color

NO_COLOR= ./my-cli  # YES PRINT COLOR
```