### PR TITLE
Add `help_header_override` command option

### DIFF
--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -186,7 +186,7 @@ module Bashly
 
       assert_string "#{key}.name", value['name']
       assert_optional_string "#{key}.help", value['help']
-      assert_optional_string "#{key}.header_override", value['header_override']
+      assert_optional_string "#{key}.help_header_override", value['help_header_override']
       assert_optional_string "#{key}.footer", value['footer']
       assert_optional_string "#{key}.group", value['group']
       assert_optional_string "#{key}.filename", value['filename']

--- a/lib/bashly/config_validator.rb
+++ b/lib/bashly/config_validator.rb
@@ -186,6 +186,7 @@ module Bashly
 
       assert_string "#{key}.name", value['name']
       assert_optional_string "#{key}.help", value['help']
+      assert_optional_string "#{key}.header_override", value['header_override']
       assert_optional_string "#{key}.footer", value['footer']
       assert_optional_string "#{key}.group", value['group']
       assert_optional_string "#{key}.filename", value['filename']

--- a/lib/bashly/script/command.rb
+++ b/lib/bashly/script/command.rb
@@ -17,7 +17,7 @@ module Bashly
             alias args catch_all commands completions
             default dependencies environment_variables examples
             extensible expose filename filters flags
-            footer function group help header_override name
+            footer function group help help_header_override name
             private variables version
           ]
         end

--- a/lib/bashly/script/command.rb
+++ b/lib/bashly/script/command.rb
@@ -17,7 +17,7 @@ module Bashly
             alias args catch_all commands completions
             default dependencies environment_variables examples
             extensible expose filename filters flags
-            footer function group help name
+            footer function group help header_override name
             private variables version
           ]
         end

--- a/lib/bashly/views/command/usage.gtx
+++ b/lib/bashly/views/command/usage.gtx
@@ -1,12 +1,12 @@
 = view_marker
 
 > {{ function_name }}_usage() {
-if summary == help && !header_override
+if summary == help && !help_header_override
   >   printf "{{ caption_string.sanitize_for_print }}\n\n"
 else
   >   if [[ -n $long_usage ]]; then
-  if header_override
-    = header_override.indent 4
+  if help_header_override
+    = help_header_override.indent 4
   else
     >     printf "{{ full_name }}\n\n"
     >     printf "{{ help.wrap(78).indent(2).sanitize_for_print }}\n\n"

--- a/lib/bashly/views/command/usage.gtx
+++ b/lib/bashly/views/command/usage.gtx
@@ -1,12 +1,16 @@
 = view_marker
 
 > {{ function_name }}_usage() {
-if summary == help
+if summary == help && !header_override
   >   printf "{{ caption_string.sanitize_for_print }}\n\n"
 else
   >   if [[ -n $long_usage ]]; then
-  >     printf "{{ full_name }}\n\n"
-  >     printf "{{ help.wrap(78).indent(2).sanitize_for_print }}\n\n"
+  if header_override
+    = header_override.indent 4
+  else
+    >     printf "{{ full_name }}\n\n"
+    >     printf "{{ help.wrap(78).indent(2).sanitize_for_print }}\n\n"
+  end
   >   else
   >     printf "{{ caption_string.sanitize_for_print }}\n\n"
   >   fi


### PR DESCRIPTION
cc #619

Add the ability to completely override the header of the `--help` output. The primary use case for this is the desire to show ascii art instead of the usual `$appname\n\nl$ong_help` output.