### PR TITLE
fix quoted here heredocs

### DIFF
--- a/lib/bashly/concerns/indentation_helper.rb
+++ b/lib/bashly/concerns/indentation_helper.rb
@@ -35,7 +35,7 @@ module Bashly
     end
 
     def extract_heredoc_marker(line)
-      line =~ /<<-?\s*(\w+)/ ? $1 : nil
+      line =~ /<<-?\s*['"]?(\w+)['"]?/ ? $1 : nil
     end
 
     def heredoc_closed?(line)

--- a/spec/bashly/extensions/array_spec.rb
+++ b/spec/bashly/extensions/array_spec.rb
@@ -45,6 +45,74 @@ describe Array do
         expect(subject.indent 2).to eq expected
       end
     end
+
+    context 'when the string contains a single quoted heredoc block' do
+      subject do
+        result = <<~SUBJECT
+          function() {
+            cat <<-'SOME_EOF_MARKER'
+          not-indented
+            indented-once
+              indented-twice
+          SOME_EOF_MARKER
+          } # indented with function() start
+        SUBJECT
+
+        result.lines
+      end
+
+      let(:expected) do
+        result = <<~SUBJECT
+            function() {
+              cat <<-'SOME_EOF_MARKER'
+          not-indented
+            indented-once
+              indented-twice
+          SOME_EOF_MARKER
+            } # indented with function() start
+        SUBJECT
+
+        result.lines
+      end
+
+      it 'does not indent it but indents everything else' do
+        expect(subject.indent 2).to eq expected
+      end
+    end
+
+    context 'when the string contains a double quoted heredoc block' do
+      subject do
+        result = <<~SUBJECT
+          function() {
+            cat <<-"SOME_EOF_MARKER"
+          not-indented
+            indented-once
+              indented-twice
+          SOME_EOF_MARKER
+          } # indented with function() start
+        SUBJECT
+
+        result.lines
+      end
+
+      let(:expected) do
+        result = <<~SUBJECT
+            function() {
+              cat <<-"SOME_EOF_MARKER"
+          not-indented
+            indented-once
+              indented-twice
+          SOME_EOF_MARKER
+            } # indented with function() start
+        SUBJECT
+
+        result.lines
+      end
+
+      it 'does not indent it but indents everything else' do
+        expect(subject.indent 2).to eq expected
+      end
+    end
   end
 
   describe '#nonuniq' do


### PR DESCRIPTION
Hello,

First off, thank you for creating and maintaining Bashly.  I found it recently and it is an incredibly well-designed tool that has made writing and managing Bash scripts so much easier and more structured. I really appreciate the effort and dedication you’ve put into this project. Keep up the fantastic work!

This PR adds handling for quoted heredocs. Right now, Bashly doesn't recognize quoted heredocs so the generated script fails with syntax errors when executed. 

When the heredoc delimiter is single-quoted or double-quoted, lines in the here-document are not expanded (parameter expansion, command substitution, etc... are ignored). Here is a [link](https://www.gnu.org/software/bash/manual/bash.html#Here-Documents) to the related section in the Bash manual. Also, this [article](https://phoenixnap.com/kb/bash-heredoc#Bash_HereDoc_Syntax) may help explain a bit further.

Link related: #496