### PR TITLE
avoid conflict with run() function with another bash frameworks

### DIFF
--- a/lib/bashly/libraries/settings/settings.yml
+++ b/lib/bashly/libraries/settings/settings.yml
@@ -126,3 +126,8 @@ var_aliases:
   other_args: ~
   deps: ~
   env_var_names: ~
+
+# Choose different names for some of the internal functions.
+function_names:
+  run: ~
+  initialize: ~

--- a/lib/bashly/settings.rb
+++ b/lib/bashly/settings.rb
@@ -15,6 +15,7 @@ module Bashly
         :enable_inspect_args,
         :enable_sourcing,
         :enable_view_markers,
+        :function_names,
         :lib_dir,
         :partials_extension,
         :private_reveal_key,
@@ -87,6 +88,14 @@ module Bashly
 
       def full_lib_dir
         "#{source_dir}/#{lib_dir}"
+      end
+
+      def function_name(key)
+        function_names[key.to_s] || key.to_s
+      end
+
+      def function_names
+        @function_names ||= get :function_names
       end
 
       def lib_dir

--- a/lib/bashly/views/command/initialize.gtx
+++ b/lib/bashly/views/command/initialize.gtx
@@ -1,6 +1,6 @@
 = view_marker
 
-> initialize() {
+> {{ Settings.function_name :initialize }}() {
 >   declare -g version="<%= version %>"
 >   {{ Settings.strict_string }}
 

--- a/lib/bashly/views/command/master_script.gtx
+++ b/lib/bashly/views/command/master_script.gtx
@@ -16,10 +16,10 @@
 if Settings.enabled? :sourcing
   > if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   >   initialize
-  >   run "$@"
+  >   {{ function_name }}_run "$@"
   > fi
 else
   > initialize
-  > run "$@"
+  > {{ function_name }}_run "$@"
 end
 > 

--- a/lib/bashly/views/command/master_script.gtx
+++ b/lib/bashly/views/command/master_script.gtx
@@ -15,11 +15,11 @@
 > 
 if Settings.enabled? :sourcing
   > if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  >   initialize
-  >   {{ function_name }}_run "$@"
+  >   {{ Settings.function_name :initialize }}
+  >   {{ Settings.function_name :run }} "$@"
   > fi
 else
-  > initialize
-  > {{ function_name }}_run "$@"
+  > {{ Settings.function_name :initialize }}
+  > {{ Settings.function_name :run }} "$@"
 end
 > 

--- a/lib/bashly/views/command/run.gtx
+++ b/lib/bashly/views/command/run.gtx
@@ -1,6 +1,6 @@
 = view_marker
 
-> {{ function_name }}_run() {
+> {{ Settings.function_name :run }}() {
 = render(:globals).indent(2)
 >
 >   normalize_input "$@"

--- a/lib/bashly/views/command/run.gtx
+++ b/lib/bashly/views/command/run.gtx
@@ -1,6 +1,6 @@
 = view_marker
 
-> run() {
+> {{ function_name }}_run() {
 = render(:globals).indent(2)
 >
 >   normalize_input "$@"


### PR DESCRIPTION
When I am trying to use 'bashmatic' framework for my new bash script, run() function from this framework is conflicting with run() function from bashly generated script