### PR TITLE
Add `markdown_github` render template

### DIFF
--- a/lib/bashly/commands/render.rb
+++ b/lib/bashly/commands/render.rb
@@ -52,7 +52,7 @@ module Bashly
 
       def show_list
         RenderSource.internal.each_value do |source|
-          say "g`:#{source.selector.to_s.ljust 10}`  #{source.summary}"
+          say "g`:#{source.selector.to_s.ljust 16}`  #{source.summary}"
         end
       end
 

--- a/lib/bashly/libraries/render/mandoc/summary.txt
+++ b/lib/bashly/libraries/render/mandoc/summary.txt
@@ -1,1 +1,1 @@
-Render man pages for your script
+Render man pages

--- a/lib/bashly/libraries/render/markdown/summary.txt
+++ b/lib/bashly/libraries/render/markdown/summary.txt
@@ -1,1 +1,1 @@
-Render markdown documents for your script
+Render markdown documents

--- a/lib/bashly/libraries/render/markdown_github/README.md
+++ b/lib/bashly/libraries/render/markdown_github/README.md
@@ -1,0 +1,37 @@
+# Render GitHub markdown
+
+Render GitHub-compatible markdown documents for your script.
+
+## Usage
+
+```bash
+# Generate all documents to the ./docs directory
+$ bashly render :markdown_github docs
+
+# Generate on change, and show one of the files
+$ bashly render :markdown_github docs --watch --show index.md
+```
+
+The differences between this template and the `:markdown` template are:
+
+- Links to sub-command files include the `.md` extension.
+- The main file is named `README.md` instead of `index.md`.
+
+## Supported custom definitions
+
+Add these definitions to your `bashly.yml` to render them in your
+markdown:
+
+### Footer: `x_markdown_footer`
+
+Add additional sections to your man pages. This field is expected
+to be in markdown format.
+
+#### Example
+
+```yaml
+x_markdown_footer: |-
+  # ISSUE TRACKER
+
+  Report issues at <https://github.com/lanalang/smallville>
+```

--- a/lib/bashly/libraries/render/markdown_github/markdown.gtx
+++ b/lib/bashly/libraries/render/markdown_github/markdown.gtx
@@ -1,0 +1,190 @@
+# === Header
+
+> # {{ full_name }}
+>
+> {{ help.for_markdown }}
+>
+
+attributes = version || alt.any? || default || extensible
+
+if attributes
+  > | Attributes       | &nbsp;
+  > |------------------|-------------
+  if version
+    > | Version:         | {{ version }}
+  end
+  if alt.any?
+    > | Alias:           | {{ alt.join ', ' }}
+  end
+  if default
+    > | Default Command: | ✓ Yes
+  end
+  if extensible
+    > | Extensible:      | {{ extensible.is_a?(String) ? extensible : "✓ Yes" }}
+  end
+  >
+end
+
+# === Usage
+
+> ## Usage
+>
+> ```bash
+> {{ usage_string.for_markdown }}
+> ```
+>
+
+# === Examples
+
+if examples
+  > ## Examples
+  >
+  examples.each do |example|
+    > ```bash
+    > {{ example }}
+    > ```
+    >
+  end
+end
+
+# === Dependencies
+
+if dependencies.any?
+  > ## Dependencies
+  >
+  dependencies.each do |dependency|
+    > #### *{{ dependency.commands.join ', ' }}*
+    >
+    > {{ dependency.help&.for_markdown }}
+    >
+  end
+end
+
+# === Environment Variables
+
+if visible_environment_variables.any?
+  > ## Environment Variables
+  >
+  visible_environment_variables.each do |environment_variable|
+    attributes = environment_variable.required || environment_variable.default
+
+    > #### *{{ environment_variable.name.upcase }}*
+    >
+    > {{ environment_variable.help.for_markdown }}
+    >
+
+    if attributes
+      > | Attributes      | &nbsp;
+      > |-----------------|-------------
+      if environment_variable.required
+        > | Required:       | ✓ Yes
+      end
+      if environment_variable.default
+        > | Default Value:  | {{ environment_variable.default }}
+      end
+      >
+    end
+  end
+end
+
+# === Commands
+
+if commands.any?
+  grouped_commands.each do |group, commands|
+    > ## {{ group.gsub(/:$/, '') }}
+    >
+    commands.each do |subcommand|
+      > - [{{ subcommand.name }}]({{ subcommand.full_name.gsub(' ', '%20') }}.md) - {{ subcommand.summary.for_markdown }}
+    end
+    >
+  end
+end
+
+# === Arguments
+
+if args.any?
+  > ## Arguments
+  >
+  args.each do |arg|
+    attributes = arg.required || arg.repeatable || arg.default || arg.allowed
+
+    > #### *{{ arg.name.upcase }}*
+    >
+    > {{ arg.help.for_markdown }}
+    >
+
+    if attributes
+      > | Attributes      | &nbsp;
+      > |-----------------|-------------
+      if arg.required
+        > | Required:       | ✓ Yes
+      end
+      if arg.repeatable
+        > | Repeatable:     |  ✓ Yes
+      end
+      if arg.default
+        > | Default Value:  | {{ arg.default }}
+      end
+      if arg.allowed
+        > | Allowed Values: | {{ arg.allowed.join(', ') }}
+      end
+      >
+    end
+  end
+
+  if catch_all.label && catch_all.help
+    > #### *{{ catch_all.label }}*
+    >
+    > {{ catch_all.help&.for_markdown }}
+    >
+    if catch_all.required?
+      > | Attributes | &nbsp;
+      > |------------|-------------
+      > | Required:  | ✓ Yes
+      >
+    end
+  end
+end
+
+# === Flags
+
+if flags.any?
+  > ## Options
+  >
+  flags.each do |flag|
+    attributes = flag.required || flag.repeatable || flag.default ||
+      flag.allowed || flag.conflicts || flag.needs
+
+    > #### *{{ flag.usage_string }}*
+    >
+    > {{ flag.help.for_markdown }}
+    >
+
+    if attributes
+      > | Attributes      | &nbsp;
+      > |-----------------|-------------
+      if flag.required
+        > | Required:       | ✓ Yes
+      end
+      if flag.repeatable
+        > | Repeatable:     |  ✓ Yes
+      end
+      if flag.default
+        > | Default Value:  | {{ flag.default }}
+      end
+      if flag.allowed
+        > | Allowed Values: | {{ flag.allowed.join(', ') }}
+      end
+      if flag.conflicts
+        > | Conflicts With: | *{{ flag.conflicts.join(', ') }}*
+      end
+      if flag.needs
+        > | Needs: | *{{ flag.needs.join(', ') }}*
+      end
+      >
+    end
+  end
+end
+
+= x_markdown_footer&.for_manpage
+>

--- a/lib/bashly/libraries/render/markdown_github/render.rb
+++ b/lib/bashly/libraries/render/markdown_github/render.rb
@@ -1,0 +1,23 @@
+# render script - markdown
+require 'gtx'
+
+# for previewing only (not needed for rendering)
+require 'tty-markdown'
+
+# Load the GTX template
+template = "#{source}/markdown.gtx"
+gtx = GTX.load_file template
+
+# Render the file for the main command
+save "#{target}/README.md", gtx.parse(command)
+
+# Render a file for each subcommand
+command.deep_commands.reject(&:private).each do |subcommand|
+  save "#{target}/#{subcommand.full_name}.md", gtx.parse(subcommand)
+end
+
+# Show one of the files if requested
+if show
+  file = "#{target}/#{show}"
+  puts TTY::Markdown.parse_file(file) if File.exist?(file)
+end

--- a/lib/bashly/libraries/render/markdown_github/summary.txt
+++ b/lib/bashly/libraries/render/markdown_github/summary.txt
@@ -1,0 +1,1 @@
+Render GitHub-compatible markdown documents

--- a/spec/approvals/cli/render/list
+++ b/spec/approvals/cli/render/list
@@ -1,2 +1,3 @@
-:mandoc      Render man pages for your script
-:markdown    Render markdown documents for your script
+:mandoc            Render man pages
+:markdown          Render markdown documents
+:markdown_github   Render GitHub-compatible markdown documents

--- a/spec/bashly/render_source_spec.rb
+++ b/spec/bashly/render_source_spec.rb
@@ -7,7 +7,7 @@ describe RenderSource do
   describe '::internal' do
     it 'returns a hash of all internal RenderSource objects' do
       expect(described_class.internal).to be_a Hash
-      expect(described_class.internal.keys).to match_array(%i[markdown mandoc])
+      expect(described_class.internal.keys).to match_array(%i[markdown markdown_github mandoc])
       expect(described_class.internal.values).to all(be_a described_class)
     end
   end


### PR DESCRIPTION
cc #638

This PR adds a new `bashly render :github_markdown` render template, with two minor differences compared to the `:markdown` template:

1. Links to sub-command documents will include the `.md` extension
2. The main file will be called `README.md` instead of `index.md`
