### PR TITLE
String in stderr also fails filters/validations

### DIFF
--- a/lib/bashly/views/argument/validations.gtx
+++ b/lib/bashly/views/argument/validations.gtx
@@ -6,15 +6,17 @@ if validate
     >   values=''
     >   eval "values=(${args['{{ name }}']})"
     >   for value in "${values[@]}"; do
-    >     if [[ -n $(validate_{{ validate }} "$value") ]]; then
-    >       printf "{{ strings[:validation_error] }}\n" "{{ name.upcase }}" "$(validate_{{ validate }} "$value")" >&2
+    >     validation_output="$(validate_{{ validate }} "$value" 2>&1)"
+    >     if [[ -n "$validation_output" ]]; then
+    >       printf "{{ strings[:validation_error] }}\n" "{{ name.upcase }}" "$validation_output" >&2
     >       exit 1
     >     fi
     >   done
     > fi
   else
-    > if [[ -v args['{{ name }}'] && -n $(validate_{{ validate }} "${args['{{ name }}']:-}") ]]; then
-    >   printf "{{ strings[:validation_error] }}\n" "{{ name.upcase }}" "$(validate_{{ validate }} "${args['{{ name }}']:-}")" >&2
+    > validation_output="$(validate_{{ validate }} "${args['{{ name }}']:-}" 2>&1)"
+    > if [[ -v args['{{ name }}'] && -n "$validation_output" ]]; then
+    >   printf "{{ strings[:validation_error] }}\n" "{{ name.upcase }}" "$validation_output" >&2
     >   exit 1
     > fi
     >

--- a/lib/bashly/views/command/user_filter.gtx
+++ b/lib/bashly/views/command/user_filter.gtx
@@ -3,7 +3,7 @@ if filters
   = view_marker
 
   filters.each do |filter|
-    > filter_error=$(filter_{{ filter }})
+    > filter_error=$(filter_{{ filter }} 2>&1)
     > if [[ -n $filter_error ]]; then
     >   echo "$filter_error" >&2
     >   exit 1

--- a/lib/bashly/views/flag/validations.gtx
+++ b/lib/bashly/views/flag/validations.gtx
@@ -6,7 +6,7 @@ if validate
     >   values=''
     >   eval "values=(${args['{{ long }}']})"
     >   for value in "${values[@]}"; do
-    >     validation_output="$(validate_{{ validate }} "$value")"
+    >     validation_output="$(validate_{{ validate }} "$value" 2>&1)"
     >     if [[ -n "$validation_output" ]]; then
     >       printf "{{ strings[:validation_error] }}\n" "{{ usage_string }}" "$validation_output" >&2
     >       exit 1
@@ -15,7 +15,7 @@ if validate
     > fi
   else
     > if [[ -v args['{{ long }}'] ]]; then
-    >   validation_output="$(validate_{{ validate }} "${args['{{ long }}']:-}")"
+    >   validation_output="$(validate_{{ validate }} "${args['{{ long }}']:-}" 2>&1)"
     >   if [[ -n "${validation_output}" ]]; then
     >     printf "{{ strings[:validation_error] }}\n" "{{ usage_string }}" "$validation_output" >&2
     >     exit 1


### PR DESCRIPTION
When a validate or filter function prints to stderr it's not considered a failure. I'm assuming such behavior is unintended, therefore I'm sending this PR.

It also does in `lib/bashly/views/argument/validations.gtx` a similar thing done in #629, preventing the `validate_*` function from running twice.